### PR TITLE
Feat: 당근 흔들기 API 구현

### DIFF
--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -2,10 +2,11 @@ import { Module } from '@nestjs/common';
 import { AppController } from './app.controller';
 import { AppService } from './app.service';
 import { DbModule } from './db/db.module';
+import { DanggnsModule } from './danggn/danggns.module';
 import { RedisModule } from './redis/redis.module';
 
 @Module({
-  imports: [DbModule, RedisModule],
+  imports: [DbModule, RedisModule, DanggnsModule],
   controllers: [AppController],
   providers: [AppService],
 })

--- a/src/danggn/danggns-cache.repository.ts
+++ b/src/danggn/danggns-cache.repository.ts
@@ -1,0 +1,37 @@
+import { Inject, Injectable } from '@nestjs/common';
+import Redis from 'ioredis';
+import { REDIS_CLIENT } from '../redis/redis.constants';
+
+const LAST_SENT_AT_TTL_SECONDS = 60;
+
+@Injectable()
+export class DanggnsCacheRepository {
+  constructor(@Inject(REDIS_CLIENT) private readonly redisClient: Redis) {}
+
+  private getFeverKey(memberId: number) {
+    return `danggns:member:${memberId}:fever`;
+  }
+
+  private getLastSentAtKey(memberId: number) {
+    return `danggns:member:${memberId}:lastSentAt`;
+  }
+
+  async exists(memberId: number): Promise<boolean> {
+    const key = this.getFeverKey(memberId);
+    return (await this.redisClient.exists(key)) === 1;
+  }
+
+  async getLastSentAt(memberId: number): Promise<number | null> {
+    const value = await this.redisClient.get(this.getLastSentAtKey(memberId));
+    return value !== null ? Number(value) : null;
+  }
+
+  async setLastSentAt(memberId: number, timestamp: number): Promise<void> {
+    await this.redisClient.set(
+      this.getLastSentAtKey(memberId),
+      timestamp,
+      'EX',
+      LAST_SENT_AT_TTL_SECONDS,
+    );
+  }
+}

--- a/src/danggn/danggns.controller.ts
+++ b/src/danggn/danggns.controller.ts
@@ -1,0 +1,25 @@
+import { Body, Controller, Post } from '@nestjs/common';
+import { ZodValidationPipe } from '../common/pipes/zod-validation.pipe';
+import {
+  DanggnsShakeRequestDto,
+  DanggnsShakeRequestSchema,
+} from './dto/danggns-shake-request.dto';
+import { DanggnsService } from './danggns.service';
+
+@Controller('danggns')
+export class DanggnsController {
+  constructor(private readonly danggnsService: DanggnsService) {}
+
+  @Post('shakes')
+  createShake(
+    @Body(new ZodValidationPipe(DanggnsShakeRequestSchema))
+    body: DanggnsShakeRequestDto,
+  ) {
+    return this.danggnsService.handleShake(
+      body.roundId,
+      body.shakeCount,
+      body.sentAt,
+      body.isFever,
+    );
+  }
+}

--- a/src/danggn/danggns.exception.ts
+++ b/src/danggn/danggns.exception.ts
@@ -1,0 +1,40 @@
+import { HttpStatus } from '@nestjs/common';
+import { BaseException } from '../common/exception/base.exception';
+
+export class DanggnsException extends BaseException {
+  private constructor(status: number, errorCode: string, message: string) {
+    super(status, errorCode, message);
+  }
+
+  static roundClosed() {
+    return new DanggnsException(
+      HttpStatus.FORBIDDEN,
+      'ROUND_CLOSED',
+      '해당 회차는 이미 종료되었습니다.',
+    );
+  }
+
+  static roundNotFound() {
+    return new DanggnsException(
+      HttpStatus.NOT_FOUND,
+      'ROUND_NOT_FOUND',
+      '해당 회차 정보를 찾을 수 없습니다.',
+    );
+  }
+
+  static abnormalShakeCount() {
+    return new DanggnsException(
+      HttpStatus.BAD_REQUEST,
+      'ABNORMAL_SHAKE_COUNT',
+      '비정상적인 흔들기 횟수가 감지되었습니다.',
+    );
+  }
+
+  static feverNotActive() {
+    return new DanggnsException(
+      HttpStatus.FORBIDDEN,
+      'FEVER_NOT_ACTIVE',
+      '현재 피버 상태가 아닙니다.',
+    );
+  }
+}

--- a/src/danggn/danggns.module.ts
+++ b/src/danggn/danggns.module.ts
@@ -1,0 +1,17 @@
+import { Module } from '@nestjs/common';
+import { DanggnsController } from './danggns.controller';
+import { RankingRepository } from './ranking.repository';
+import { DanggnsRepository } from './danggns.repository';
+import { DanggnsService } from './danggns.service';
+import { DanggnsCacheRepository } from './danggns-cache.repository';
+
+@Module({
+  controllers: [DanggnsController],
+  providers: [
+    RankingRepository,
+    DanggnsRepository,
+    DanggnsCacheRepository,
+    DanggnsService,
+  ],
+})
+export class DanggnsModule {}

--- a/src/danggn/danggns.repository.ts
+++ b/src/danggn/danggns.repository.ts
@@ -1,0 +1,26 @@
+import { Inject, Injectable } from '@nestjs/common';
+import { eq } from 'drizzle-orm';
+import type { NodePgDatabase } from 'drizzle-orm/node-postgres';
+import { DRIZZLE_DB } from '../db/db.constants';
+import * as schema from '../schema';
+
+@Injectable()
+export class DanggnsRepository {
+  constructor(
+    @Inject(DRIZZLE_DB) private readonly db: NodePgDatabase<typeof schema>,
+  ) {}
+
+  findRoundById(roundId: number) {
+    return this.db.query.carrotRounds.findFirst({
+      where: eq(schema.carrotRounds.id, roundId),
+    });
+  }
+
+  insertShakeEvent(payload: {
+    roundId: number;
+    memberId: number;
+    scoreDelta: number;
+  }) {
+    return this.db.insert(schema.carrotShakeEvents).values(payload);
+  }
+}

--- a/src/danggn/danggns.service.spec.ts
+++ b/src/danggn/danggns.service.spec.ts
@@ -1,0 +1,226 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { DanggnsService } from './danggns.service';
+import { DanggnsRepository } from './danggns.repository';
+import { RankingRepository } from './ranking.repository';
+import { DanggnsCacheRepository } from './danggns-cache.repository';
+import { DanggnsException } from './danggns.exception';
+
+const MOCK_ROUND = {
+  id: 1,
+  generationId: 1,
+  roundNo: 1,
+  startedAt: new Date('2020-01-01'),
+  endedAt: new Date('2099-01-01'),
+  createdAt: new Date(),
+  updatedAt: new Date(),
+};
+
+describe('DanggnsService', () => {
+  let service: DanggnsService;
+  let danggnsRepository: jest.Mocked<DanggnsRepository>;
+  let rankingRepository: jest.Mocked<RankingRepository>;
+  let danggnsCacheRepository: jest.Mocked<DanggnsCacheRepository>;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        DanggnsService,
+        {
+          provide: DanggnsRepository,
+          useValue: {
+            findRoundById: jest.fn(),
+            insertShakeEvent: jest.fn(),
+          },
+        },
+        {
+          provide: RankingRepository,
+          useValue: {
+            zIncrBy: jest.fn(),
+          },
+        },
+        {
+          provide: DanggnsCacheRepository,
+          useValue: {
+            getLastSentAt: jest.fn(),
+            setLastSentAt: jest.fn(),
+            exists: jest.fn(),
+          },
+        },
+      ],
+    }).compile();
+
+    service = module.get(DanggnsService);
+    danggnsRepository = module.get(DanggnsRepository);
+    rankingRepository = module.get(RankingRepository);
+    danggnsCacheRepository = module.get(DanggnsCacheRepository);
+
+    danggnsRepository.findRoundById.mockResolvedValue(MOCK_ROUND);
+    danggnsRepository.insertShakeEvent.mockResolvedValue(undefined as any);
+    rankingRepository.zIncrBy.mockResolvedValue('100');
+    danggnsCacheRepository.getLastSentAt.mockResolvedValue(null);
+    danggnsCacheRepository.setLastSentAt.mockResolvedValue(undefined);
+    danggnsCacheRepository.exists.mockResolvedValue(false);
+  });
+
+  describe('handleShake', () => {
+    const ROUND_ID = 1;
+    const SHAKE_COUNT = 10;
+    const SENT_AT = new Date().toISOString();
+
+    describe('정상 처리', () => {
+      it('일반 흔들기 - appliedScore가 shakeCount와 동일하고 isFeverApplied가 false다', async () => {
+        const result = await service.handleShake(
+          ROUND_ID,
+          SHAKE_COUNT,
+          SENT_AT,
+          false,
+        );
+
+        expect(result).toEqual({
+          appliedScore: SHAKE_COUNT,
+          currentRoundScore: 100,
+          currentCrewScore: 100,
+          isFeverApplied: false,
+        });
+      });
+
+      it('피버 흔들기 - appliedScore가 shakeCount * 10이고 isFeverApplied가 true다', async () => {
+        danggnsCacheRepository.exists.mockResolvedValue(true);
+
+        const result = await service.handleShake(
+          ROUND_ID,
+          SHAKE_COUNT,
+          SENT_AT,
+          true,
+        );
+
+        expect(result).toEqual({
+          appliedScore: SHAKE_COUNT * 10,
+          currentRoundScore: 100,
+          currentCrewScore: 100,
+          isFeverApplied: true,
+        });
+      });
+
+      it('성공 후 setLastSentAt을 호출한다', async () => {
+        await service.handleShake(ROUND_ID, SHAKE_COUNT, SENT_AT, false);
+
+        expect(danggnsCacheRepository.setLastSentAt).toHaveBeenCalledWith(
+          1,
+          expect.any(Number),
+        );
+      });
+
+      it('lastSentAt이 null이면 물리적 속도 체크를 스킵하고 성공한다', async () => {
+        danggnsCacheRepository.getLastSentAt.mockResolvedValue(null);
+
+        await expect(
+          service.handleShake(ROUND_ID, 1500, SENT_AT, false),
+        ).resolves.toMatchObject({ appliedScore: 1500 });
+      });
+    });
+
+    describe('라운드 검증', () => {
+      it('라운드가 없으면 ROUND_NOT_FOUND 예외를 던진다', async () => {
+        danggnsRepository.findRoundById.mockResolvedValue(undefined);
+
+        const err = await service
+          .handleShake(ROUND_ID, SHAKE_COUNT, SENT_AT, false)
+          .catch((e) => e);
+
+        expect(err).toBeInstanceOf(DanggnsException);
+        expect(err.getResponse()).toMatchObject({
+          errorCode: 'ROUND_NOT_FOUND',
+        });
+      });
+
+      it('sentAt이 라운드 시작 전이면 ROUND_CLOSED 예외를 던진다', async () => {
+        const beforeRoundStart = new Date('2019-06-01').toISOString();
+
+        const err = await service
+          .handleShake(ROUND_ID, SHAKE_COUNT, beforeRoundStart, false)
+          .catch((e) => e);
+
+        expect(err).toBeInstanceOf(DanggnsException);
+        expect(err.getResponse()).toMatchObject({ errorCode: 'ROUND_CLOSED' });
+      });
+
+      it('sentAt이 라운드 종료 후면 ROUND_CLOSED 예외를 던진다', async () => {
+        const afterRoundEnd = new Date('2100-01-01').toISOString();
+
+        const err = await service
+          .handleShake(ROUND_ID, SHAKE_COUNT, afterRoundEnd, false)
+          .catch((e) => e);
+
+        expect(err).toBeInstanceOf(DanggnsException);
+        expect(err.getResponse()).toMatchObject({ errorCode: 'ROUND_CLOSED' });
+      });
+    });
+
+    describe('어뷰징 검증', () => {
+      it('shakeCount가 0이면 ABNORMAL_SHAKE_COUNT 예외를 던진다', async () => {
+        const err = await service
+          .handleShake(ROUND_ID, 0, SENT_AT, false)
+          .catch((e) => e);
+
+        expect(err).toBeInstanceOf(DanggnsException);
+        expect(err.getResponse()).toMatchObject({
+          errorCode: 'ABNORMAL_SHAKE_COUNT',
+        });
+      });
+
+      it('shakeCount가 1500을 초과하면 ABNORMAL_SHAKE_COUNT 예외를 던진다', async () => {
+        const err = await service
+          .handleShake(ROUND_ID, 1501, SENT_AT, false)
+          .catch((e) => e);
+
+        expect(err).toBeInstanceOf(DanggnsException);
+        expect(err.getResponse()).toMatchObject({
+          errorCode: 'ABNORMAL_SHAKE_COUNT',
+        });
+      });
+
+      it('sentAt이 현재 시각보다 5초 이상 미래면 ABNORMAL_SHAKE_COUNT 예외를 던진다', async () => {
+        const futureSentAt = new Date(Date.now() + 10_000).toISOString();
+
+        const err = await service
+          .handleShake(ROUND_ID, SHAKE_COUNT, futureSentAt, false)
+          .catch((e) => e);
+
+        expect(err).toBeInstanceOf(DanggnsException);
+        expect(err.getResponse()).toMatchObject({
+          errorCode: 'ABNORMAL_SHAKE_COUNT',
+        });
+      });
+
+      it('lastSentAt 기준 물리적 속도를 초과하면 ABNORMAL_SHAKE_COUNT 예외를 던진다', async () => {
+        // 직전 요청이 방금 있었으므로 elapsed ≈ 0 → 1초로 클램프 → 최대 20회
+        danggnsCacheRepository.getLastSentAt.mockResolvedValue(Date.now());
+
+        const err = await service
+          .handleShake(ROUND_ID, 100, SENT_AT, false)
+          .catch((e) => e);
+
+        expect(err).toBeInstanceOf(DanggnsException);
+        expect(err.getResponse()).toMatchObject({
+          errorCode: 'ABNORMAL_SHAKE_COUNT',
+        });
+      });
+    });
+
+    describe('피버 검증', () => {
+      it('isFever가 true인데 피버 키가 없으면 FEVER_NOT_ACTIVE 예외를 던진다', async () => {
+        danggnsCacheRepository.exists.mockResolvedValue(false);
+
+        const err = await service
+          .handleShake(ROUND_ID, SHAKE_COUNT, SENT_AT, true)
+          .catch((e) => e);
+
+        expect(err).toBeInstanceOf(DanggnsException);
+        expect(err.getResponse()).toMatchObject({
+          errorCode: 'FEVER_NOT_ACTIVE',
+        });
+      });
+    });
+  });
+});

--- a/src/danggn/danggns.service.ts
+++ b/src/danggn/danggns.service.ts
@@ -1,0 +1,137 @@
+import { Injectable } from '@nestjs/common';
+import { DanggnsException } from './danggns.exception';
+import { DanggnsRepository } from './danggns.repository';
+import { DanggnsCacheRepository } from './danggns-cache.repository';
+import { RankingRepository } from './ranking.repository';
+
+export type DanggnsShakeResponseDto = {
+  appliedScore: number;
+  currentRoundScore: number;
+  currentCrewScore: number;
+  isFeverApplied: boolean;
+};
+
+const MOCK_USER_ID = 1;
+const MOCK_PLATFORM = 'NODE';
+const MAX_SHAKE_COUNT = 1500;
+const MAX_SHAKES_PER_SECOND = 20;
+const MAX_CLIENT_TIME_SKEW_MS = 5000;
+const FEVER_MULTIPLIER = 10;
+
+@Injectable()
+export class DanggnsService {
+  constructor(
+    private readonly danggnsRepository: DanggnsRepository,
+    private readonly rankingRepository: RankingRepository,
+    private readonly danggnsCacheRepository: DanggnsCacheRepository,
+  ) {}
+
+  async handleShake(
+    roundId: number,
+    shakeCount: number,
+    sentAt: string,
+    isFever: boolean,
+  ): Promise<DanggnsShakeResponseDto> {
+    const round = await this.findRoundByIdOrThrow(roundId);
+
+    const now = new Date(sentAt);
+    if (now < round.startedAt || now > round.endedAt) {
+      throw DanggnsException.roundClosed();
+    }
+
+    const lastSentAt =
+      await this.danggnsCacheRepository.getLastSentAt(MOCK_USER_ID);
+    this.validateAbusing(shakeCount, sentAt, lastSentAt);
+    const isFeverApplied = await this.validateFever(isFever);
+
+    const appliedScore = isFeverApplied
+      ? shakeCount * FEVER_MULTIPLIER
+      : shakeCount;
+    const memberKey = this.getMemberRoundKey(roundId);
+    const crewKey = this.getCrewRoundKey(roundId);
+
+    const [currentRoundScore, currentCrewScore] = await Promise.all([
+      this.rankingRepository.zIncrBy(
+        memberKey,
+        appliedScore,
+        String(MOCK_USER_ID),
+      ),
+      this.rankingRepository.zIncrBy(crewKey, appliedScore, MOCK_PLATFORM),
+    ]);
+
+    await Promise.all([
+      this.danggnsRepository.insertShakeEvent({
+        roundId,
+        memberId: MOCK_USER_ID,
+        scoreDelta: appliedScore,
+      }),
+      this.danggnsCacheRepository.setLastSentAt(MOCK_USER_ID, Date.now()),
+    ]);
+
+    return {
+      appliedScore,
+      currentRoundScore: Number(currentRoundScore),
+      currentCrewScore: Number(currentCrewScore),
+      isFeverApplied,
+    };
+  }
+
+  private getMemberRoundKey(roundId: number) {
+    return `danggns:round:${roundId}:members`;
+  }
+
+  private getCrewRoundKey(roundId: number) {
+    return `danggns:round:${roundId}:crew`;
+  }
+
+  private async findRoundByIdOrThrow(roundId: number) {
+    const round = await this.danggnsRepository.findRoundById(roundId);
+    if (!round) {
+      throw DanggnsException.roundNotFound();
+    }
+    return round;
+  }
+
+  private validateAbusing(
+    shakeCount: number,
+    sentAt: string,
+    lastSentAt: number | null,
+  ) {
+    // 1. 단일 요청 한계치 체크
+    if (shakeCount <= 0 || shakeCount > MAX_SHAKE_COUNT) {
+      throw DanggnsException.abnormalShakeCount();
+    }
+
+    // 2. 시간 조작 체크
+    const now = Date.now();
+    if (Date.parse(sentAt) - now > MAX_CLIENT_TIME_SKEW_MS) {
+      throw DanggnsException.abnormalShakeCount();
+    }
+
+    // 3. 물리적 속도 한계 체크
+    if (lastSentAt !== null) {
+      const elapsedSeconds = Math.max(1, (now - lastSentAt) / 1000);
+      const maxPossibleCount = Math.floor(
+        MAX_SHAKES_PER_SECOND * elapsedSeconds,
+      );
+
+      if (shakeCount > maxPossibleCount) {
+        throw DanggnsException.abnormalShakeCount();
+      }
+    }
+  }
+
+  private async validateFever(isFever: boolean): Promise<boolean> {
+    // 피버 활성화 여부 교차 검증
+    if (!isFever) {
+      return false;
+    }
+
+    const feverExists = await this.danggnsCacheRepository.exists(MOCK_USER_ID);
+    if (!feverExists) {
+      throw DanggnsException.feverNotActive();
+    }
+
+    return true;
+  }
+}

--- a/src/danggn/dto/danggns-shake-request.dto.ts
+++ b/src/danggn/dto/danggns-shake-request.dto.ts
@@ -1,0 +1,12 @@
+import { z } from 'zod';
+
+export const DanggnsShakeRequestSchema = z.object({
+  roundId: z.number().int().positive(),
+  shakeCount: z.number().int().nonnegative(),
+  isFever: z.boolean(),
+  sentAt: z.string().refine((value) => !Number.isNaN(Date.parse(value)), {
+    message: 'sentAt must be a valid datetime string',
+  }),
+});
+
+export type DanggnsShakeRequestDto = z.infer<typeof DanggnsShakeRequestSchema>;

--- a/src/schema/birthday.schema.ts
+++ b/src/schema/birthday.schema.ts
@@ -1,0 +1,109 @@
+import { relations } from 'drizzle-orm';
+import {
+  bigint,
+  bigserial,
+  boolean,
+  pgEnum,
+  pgTable,
+  text,
+  timestamp,
+  unique,
+  uniqueIndex,
+  varchar,
+} from 'drizzle-orm/pg-core';
+import { generations, members } from './schema';
+
+export const birthdayImageTypeEnum = pgEnum('birthday_image_type_enum', [
+  'CAKE',
+  'GIFT',
+  'PARTY',
+  'CUSTOM',
+]);
+
+export const images = pgTable(
+  'images',
+  {
+    id: bigserial('id', { mode: 'number' }).primaryKey(),
+    uploaderId: bigint('uploader_id', { mode: 'number' })
+      .notNull()
+      .references(() => members.id, { onDelete: 'cascade' }),
+    storagePath: varchar('storage_path', { length: 2048 }).notNull(),
+    originalName: varchar('original_name', { length: 512 }).notNull(),
+    mimeType: varchar('mime_type', { length: 255 }).notNull(),
+    isActive: boolean('is_active').notNull(),
+    size: bigint('size', { mode: 'number' }).notNull(),
+    createdAt: timestamp('created_at', { withTimezone: true })
+      .notNull()
+      .defaultNow(),
+    updatedAt: timestamp('updated_at', { withTimezone: true })
+      .notNull()
+      .defaultNow()
+      .$onUpdate(() => new Date()),
+  },
+  (table) => [uniqueIndex('images_storage_path_uq').on(table.storagePath)],
+);
+
+export const birthdayCards = pgTable(
+  'birthday_cards',
+  {
+    id: bigserial('id', { mode: 'number' }).primaryKey(),
+    senderMemberId: bigint('sender_member_id', { mode: 'number' })
+      .notNull()
+      .references(() => members.id, { onDelete: 'cascade' }),
+    receiverMemberId: bigint('receiver_member_id', { mode: 'number' })
+      .notNull()
+      .references(() => members.id, { onDelete: 'cascade' }),
+    generationId: bigint('generation_id', { mode: 'number' })
+      .notNull()
+      .references(() => generations.id, { onDelete: 'cascade' }),
+    imageId: bigint('image_id', { mode: 'number' }).references(
+      () => images.id,
+      { onDelete: 'set null' },
+    ),
+    imageType: birthdayImageTypeEnum('image_type').notNull(),
+    message: text('message').notNull(),
+    createdAt: timestamp('created_at', { withTimezone: true })
+      .notNull()
+      .defaultNow(),
+    updatedAt: timestamp('updated_at', { withTimezone: true })
+      .notNull()
+      .defaultNow()
+      .$onUpdate(() => new Date()),
+  },
+  (table) => [
+    unique('birthday_cards_sender_receiver_generation_uq').on(
+      table.senderMemberId,
+      table.receiverMemberId,
+      table.generationId,
+    ),
+  ],
+);
+
+export const imagesRelations = relations(images, ({ one, many }) => ({
+  uploader: one(members, {
+    fields: [images.uploaderId],
+    references: [members.id],
+  }),
+  birthdayCards: many(birthdayCards),
+}));
+
+export const birthdayCardsRelations = relations(birthdayCards, ({ one }) => ({
+  sender: one(members, {
+    fields: [birthdayCards.senderMemberId],
+    references: [members.id],
+    relationName: 'birthday_sender',
+  }),
+  receiver: one(members, {
+    fields: [birthdayCards.receiverMemberId],
+    references: [members.id],
+    relationName: 'birthday_receiver',
+  }),
+  generation: one(generations, {
+    fields: [birthdayCards.generationId],
+    references: [generations.id],
+  }),
+  image: one(images, {
+    fields: [birthdayCards.imageId],
+    references: [images.id],
+  }),
+}));

--- a/src/schema/carrot.schema.ts
+++ b/src/schema/carrot.schema.ts
@@ -1,0 +1,177 @@
+import { relations, sql } from 'drizzle-orm';
+import {
+  bigint,
+  bigserial,
+  check,
+  index,
+  integer,
+  pgTable,
+  primaryKey,
+  timestamp,
+  unique,
+} from 'drizzle-orm/pg-core';
+import { generations, members, platformEnum } from './schema';
+
+export const carrotRounds = pgTable(
+  'carrot_rounds',
+  {
+    id: bigserial('id', { mode: 'number' }).primaryKey(),
+    generationId: bigint('generation_id', { mode: 'number' })
+      .notNull()
+      .references(() => generations.id, { onDelete: 'cascade' }),
+    roundNo: integer('round_no').notNull(),
+    startedAt: timestamp('started_at', { withTimezone: true }).notNull(),
+    endedAt: timestamp('ended_at', { withTimezone: true }).notNull(),
+    createdAt: timestamp('created_at', { withTimezone: true })
+      .notNull()
+      .defaultNow(),
+    updatedAt: timestamp('updated_at', { withTimezone: true })
+      .notNull()
+      .defaultNow()
+      .$onUpdate(() => new Date()),
+  },
+  (table) => [
+    unique('carrot_rounds_generation_round_uq').on(
+      table.generationId,
+      table.roundNo,
+    ),
+    check('carrot_rounds_round_no_gte_1_ck', sql`${table.roundNo} >= 1`),
+  ],
+);
+
+export const carrotRoundRankings = pgTable(
+  'carrot_round_rankings',
+  {
+    id: bigserial('id', { mode: 'number' }).primaryKey(),
+    roundId: bigint('round_id', { mode: 'number' })
+      .notNull()
+      .references(() => carrotRounds.id, { onDelete: 'cascade' }),
+    memberId: bigint('member_id', { mode: 'number' })
+      .notNull()
+      .references(() => members.id, { onDelete: 'cascade' }),
+    finalRank: integer('final_rank').notNull(),
+    finalScore: integer('final_score').notNull(),
+    createdAt: timestamp('created_at', { withTimezone: true })
+      .notNull()
+      .defaultNow(),
+  },
+  (table) => [
+    unique('carrot_round_rankings_round_member_uq').on(
+      table.roundId,
+      table.memberId,
+    ),
+    index('carrot_round_rankings_round_id_idx').on(table.roundId),
+    index('carrot_round_rankings_member_id_idx').on(table.memberId),
+    check(
+      'carrot_round_rankings_final_rank_gte_1_ck',
+      sql`${table.finalRank} >= 1`,
+    ),
+    check(
+      'carrot_round_rankings_final_score_gte_0_ck',
+      sql`${table.finalScore} >= 0`,
+    ),
+  ],
+);
+
+export const carrotShakeEvents = pgTable(
+  'carrot_shake_events',
+  {
+    id: bigserial('id', { mode: 'number' }).primaryKey(),
+    roundId: bigint('round_id', { mode: 'number' })
+      .notNull()
+      .references(() => carrotRounds.id, { onDelete: 'cascade' }),
+    memberId: bigint('member_id', { mode: 'number' })
+      .notNull()
+      .references(() => members.id, { onDelete: 'cascade' }),
+    scoreDelta: integer('score_delta').notNull(),
+    createdAt: timestamp('created_at', { withTimezone: true })
+      .notNull()
+      .defaultNow(),
+  },
+  (table) => [
+    index('carrot_shake_events_round_id_idx').on(table.roundId),
+    index('carrot_shake_events_member_id_idx').on(table.memberId),
+  ],
+);
+
+export const carrotStakedCount = pgTable(
+  'carrot_staked_count',
+  {
+    memberId: bigint('member_id', { mode: 'number' })
+      .notNull()
+      .references(() => members.id, { onDelete: 'cascade' }),
+    generationId: bigint('generation_id', { mode: 'number' })
+      .notNull()
+      .references(() => generations.id, { onDelete: 'cascade' }),
+    platform: platformEnum('platform').notNull(),
+    shakeCount: bigint('shake_count', { mode: 'number' }).notNull(),
+    createdAt: timestamp('created_at', { withTimezone: true })
+      .notNull()
+      .defaultNow(),
+    updatedAt: timestamp('updated_at', { withTimezone: true })
+      .notNull()
+      .defaultNow()
+      .$onUpdate(() => new Date()),
+  },
+  (table) => [
+    primaryKey({ columns: [table.memberId, table.generationId] }),
+    unique('carrot_staked_count_member_generation_uq').on(
+      table.memberId,
+      table.generationId,
+    ),
+  ],
+);
+
+export const carrotRoundsRelations = relations(
+  carrotRounds,
+  ({ one, many }) => ({
+    generation: one(generations, {
+      fields: [carrotRounds.generationId],
+      references: [generations.id],
+    }),
+    carrotRoundRankings: many(carrotRoundRankings),
+    carrotShakeEvents: many(carrotShakeEvents),
+  }),
+);
+
+export const carrotRoundRankingsRelations = relations(
+  carrotRoundRankings,
+  ({ one }) => ({
+    round: one(carrotRounds, {
+      fields: [carrotRoundRankings.roundId],
+      references: [carrotRounds.id],
+    }),
+    member: one(members, {
+      fields: [carrotRoundRankings.memberId],
+      references: [members.id],
+    }),
+  }),
+);
+
+export const carrotShakeEventsRelations = relations(
+  carrotShakeEvents,
+  ({ one }) => ({
+    round: one(carrotRounds, {
+      fields: [carrotShakeEvents.roundId],
+      references: [carrotRounds.id],
+    }),
+    member: one(members, {
+      fields: [carrotShakeEvents.memberId],
+      references: [members.id],
+    }),
+  }),
+);
+
+export const carrotStakedCountRelations = relations(
+  carrotStakedCount,
+  ({ one }) => ({
+    member: one(members, {
+      fields: [carrotStakedCount.memberId],
+      references: [members.id],
+    }),
+    generation: one(generations, {
+      fields: [carrotStakedCount.generationId],
+      references: [generations.id],
+    }),
+  }),
+);

--- a/src/schema/index.ts
+++ b/src/schema/index.ts
@@ -1,1 +1,3 @@
 export * from './schema';
+export * from './carrot.schema';
+export * from './birthday.schema';

--- a/src/schema/schema.ts
+++ b/src/schema/schema.ts
@@ -9,7 +9,6 @@ import {
   numeric,
   pgEnum,
   pgTable,
-  primaryKey,
   text,
   timestamp,
   unique,
@@ -56,13 +55,6 @@ export const attendanceCheckMethodEnum = pgEnum(
   'attendance_check_method_enum',
   ['QR', 'MANUAL'],
 );
-
-export const birthdayImageTypeEnum = pgEnum('birthday_image_type_enum', [
-  'CAKE',
-  'GIFT',
-  'PARTY',
-  'CUSTOM',
-]);
 
 export const members = pgTable('members', {
   id: bigserial('id', { mode: 'number' }).primaryKey(),
@@ -374,177 +366,6 @@ export const seminarAttendanceRecords = pgTable(
   ],
 );
 
-export const carrotRounds = pgTable(
-  'carrot_rounds',
-  {
-    id: bigserial('id', { mode: 'number' }).primaryKey(),
-    generationId: bigint('generation_id', { mode: 'number' })
-      .notNull()
-      .references(() => generations.id, { onDelete: 'cascade' }),
-    roundNo: integer('round_no').notNull(),
-    startedAt: timestamp('started_at', { withTimezone: true }).notNull(),
-    endedAt: timestamp('ended_at', { withTimezone: true }).notNull(),
-    createdAt: timestamp('created_at', { withTimezone: true })
-      .notNull()
-      .defaultNow(),
-    updatedAt: timestamp('updated_at', { withTimezone: true })
-      .notNull()
-      .defaultNow()
-      .$onUpdate(() => new Date()),
-  },
-  (table) => [
-    unique('carrot_rounds_generation_round_uq').on(
-      table.generationId,
-      table.roundNo,
-    ),
-    check('carrot_rounds_round_no_gte_1_ck', sql`${table.roundNo} >= 1`),
-  ],
-);
-
-export const carrotRoundRankings = pgTable(
-  'carrot_round_rankings',
-  {
-    id: bigserial('id', { mode: 'number' }).primaryKey(),
-    roundId: bigint('round_id', { mode: 'number' })
-      .notNull()
-      .references(() => carrotRounds.id, { onDelete: 'cascade' }),
-    memberId: bigint('member_id', { mode: 'number' })
-      .notNull()
-      .references(() => members.id, { onDelete: 'cascade' }),
-    finalRank: integer('final_rank').notNull(),
-    finalScore: integer('final_score').notNull(),
-    createdAt: timestamp('created_at', { withTimezone: true })
-      .notNull()
-      .defaultNow(),
-  },
-  (table) => [
-    unique('carrot_round_rankings_round_member_uq').on(
-      table.roundId,
-      table.memberId,
-    ),
-    index('carrot_round_rankings_round_id_idx').on(table.roundId),
-    index('carrot_round_rankings_member_id_idx').on(table.memberId),
-    check(
-      'carrot_round_rankings_final_rank_gte_1_ck',
-      sql`${table.finalRank} >= 1`,
-    ),
-    check(
-      'carrot_round_rankings_final_score_gte_0_ck',
-      sql`${table.finalScore} >= 0`,
-    ),
-  ],
-);
-
-export const carrotShakeEvents = pgTable(
-  'carrot_shake_events',
-  {
-    id: bigserial('id', { mode: 'number' }).primaryKey(),
-    roundId: bigint('round_id', { mode: 'number' })
-      .notNull()
-      .references(() => carrotRounds.id, { onDelete: 'cascade' }),
-    memberId: bigint('member_id', { mode: 'number' })
-      .notNull()
-      .references(() => members.id, { onDelete: 'cascade' }),
-    scoreDelta: integer('score_delta').notNull(),
-    createdAt: timestamp('created_at', { withTimezone: true })
-      .notNull()
-      .defaultNow(),
-  },
-  (table) => [
-    index('carrot_shake_events_round_id_idx').on(table.roundId),
-    index('carrot_shake_events_member_id_idx').on(table.memberId),
-  ],
-);
-
-export const carrotStakedCount = pgTable(
-  'carrot_staked_count',
-  {
-    memberId: bigint('member_id', { mode: 'number' })
-      .notNull()
-      .references(() => members.id, { onDelete: 'cascade' }),
-    generationId: bigint('generation_id', { mode: 'number' })
-      .notNull()
-      .references(() => generations.id, { onDelete: 'cascade' }),
-    platform: platformEnum('platform').notNull(),
-    shakeCount: bigint('shake_count', { mode: 'number' }).notNull(),
-    createdAt: timestamp('created_at', { withTimezone: true })
-      .notNull()
-      .defaultNow(),
-    updatedAt: timestamp('updated_at', { withTimezone: true })
-      .notNull()
-      .defaultNow()
-      .$onUpdate(() => new Date()),
-  },
-  (table) => [
-    primaryKey({ columns: [table.memberId, table.generationId] }),
-    unique('carrot_staked_count_member_generation_uq').on(
-      table.memberId,
-      table.generationId,
-    ),
-  ],
-);
-
-export const images = pgTable(
-  'images',
-  {
-    id: bigserial('id', { mode: 'number' }).primaryKey(),
-    uploaderId: bigint('uploader_id', { mode: 'number' })
-      .notNull()
-      .references(() => members.id, { onDelete: 'cascade' }),
-    storagePath: varchar('storage_path', { length: 2048 }).notNull(),
-    originalName: varchar('original_name', { length: 512 }).notNull(),
-    mimeType: varchar('mime_type', { length: 255 }).notNull(),
-    isActive: boolean('is_active').notNull(),
-    size: bigint('size', { mode: 'number' }).notNull(),
-    createdAt: timestamp('created_at', { withTimezone: true })
-      .notNull()
-      .defaultNow(),
-    updatedAt: timestamp('updated_at', { withTimezone: true })
-      .notNull()
-      .defaultNow()
-      .$onUpdate(() => new Date()),
-  },
-  (table) => [uniqueIndex('images_storage_path_uq').on(table.storagePath)],
-);
-
-export const birthdayCards = pgTable(
-  'birthday_cards',
-  {
-    id: bigserial('id', { mode: 'number' }).primaryKey(),
-    senderMemberId: bigint('sender_member_id', { mode: 'number' })
-      .notNull()
-      .references(() => members.id, { onDelete: 'cascade' }),
-    receiverMemberId: bigint('receiver_member_id', { mode: 'number' })
-      .notNull()
-      .references(() => members.id, { onDelete: 'cascade' }),
-    generationId: bigint('generation_id', { mode: 'number' })
-      .notNull()
-      .references(() => generations.id, { onDelete: 'cascade' }),
-    imageId: bigint('image_id', { mode: 'number' }).references(
-      () => images.id,
-      {
-        onDelete: 'set null',
-      },
-    ),
-    imageType: birthdayImageTypeEnum('image_type').notNull(),
-    message: text('message').notNull(),
-    createdAt: timestamp('created_at', { withTimezone: true })
-      .notNull()
-      .defaultNow(),
-    updatedAt: timestamp('updated_at', { withTimezone: true })
-      .notNull()
-      .defaultNow()
-      .$onUpdate(() => new Date()),
-  },
-  (table) => [
-    unique('birthday_cards_sender_receiver_generation_uq').on(
-      table.senderMemberId,
-      table.receiverMemberId,
-      table.generationId,
-    ),
-  ],
-);
-
 export const membersRelations = relations(members, ({ one, many }) => ({
   profile: one(memberProfiles, {
     fields: [members.id],
@@ -555,13 +376,6 @@ export const membersRelations = relations(members, ({ one, many }) => ({
   inviteCodeUsages: many(inviteCodeUsages),
   refreshTokens: many(refreshTokens),
   seminarAttendanceRecords: many(seminarAttendanceRecords),
-  carrotRoundRankings: many(carrotRoundRankings),
-  carrotShakeEvents: many(carrotShakeEvents),
-  sentBirthdayCards: many(birthdayCards, { relationName: 'birthday_sender' }),
-  receivedBirthdayCards: many(birthdayCards, {
-    relationName: 'birthday_receiver',
-  }),
-  uploadedImages: many(images),
 }));
 
 export const memberProfilesRelations = relations(memberProfiles, ({ one }) => ({
@@ -575,9 +389,6 @@ export const generationsRelations = relations(generations, ({ many }) => ({
   memberGenerationActivities: many(memberGenerationActivities),
   inviteCodes: many(inviteCodes),
   seminarSchedules: many(seminarSchedules),
-  carrotRounds: many(carrotRounds),
-  birthdayCards: many(birthdayCards),
-  carrotStakedCounts: many(carrotStakedCount),
 }));
 
 export const memberGenerationActivitiesRelations = relations(
@@ -681,86 +492,3 @@ export const seminarAttendanceRecordsRelations = relations(
     }),
   }),
 );
-
-export const carrotRoundsRelations = relations(
-  carrotRounds,
-  ({ one, many }) => ({
-    generation: one(generations, {
-      fields: [carrotRounds.generationId],
-      references: [generations.id],
-    }),
-    carrotRoundRankings: many(carrotRoundRankings),
-    carrotShakeEvents: many(carrotShakeEvents),
-  }),
-);
-
-export const carrotRoundRankingsRelations = relations(
-  carrotRoundRankings,
-  ({ one }) => ({
-    round: one(carrotRounds, {
-      fields: [carrotRoundRankings.roundId],
-      references: [carrotRounds.id],
-    }),
-    member: one(members, {
-      fields: [carrotRoundRankings.memberId],
-      references: [members.id],
-    }),
-  }),
-);
-
-export const carrotShakeEventsRelations = relations(
-  carrotShakeEvents,
-  ({ one }) => ({
-    round: one(carrotRounds, {
-      fields: [carrotShakeEvents.roundId],
-      references: [carrotRounds.id],
-    }),
-    member: one(members, {
-      fields: [carrotShakeEvents.memberId],
-      references: [members.id],
-    }),
-  }),
-);
-
-export const carrotStakedCountRelations = relations(
-  carrotStakedCount,
-  ({ one }) => ({
-    member: one(members, {
-      fields: [carrotStakedCount.memberId],
-      references: [members.id],
-    }),
-    generation: one(generations, {
-      fields: [carrotStakedCount.generationId],
-      references: [generations.id],
-    }),
-  }),
-);
-
-export const imagesRelations = relations(images, ({ one, many }) => ({
-  uploader: one(members, {
-    fields: [images.uploaderId],
-    references: [members.id],
-  }),
-  birthdayCards: many(birthdayCards),
-}));
-
-export const birthdayCardsRelations = relations(birthdayCards, ({ one }) => ({
-  sender: one(members, {
-    fields: [birthdayCards.senderMemberId],
-    references: [members.id],
-    relationName: 'birthday_sender',
-  }),
-  receiver: one(members, {
-    fields: [birthdayCards.receiverMemberId],
-    references: [members.id],
-    relationName: 'birthday_receiver',
-  }),
-  generation: one(generations, {
-    fields: [birthdayCards.generationId],
-    references: [generations.id],
-  }),
-  image: one(images, {
-    fields: [birthdayCards.imageId],
-    references: [images.id],
-  }),
-}));

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -16,6 +16,6 @@
     "noImplicitAny": false,
     "strictBindCallApply": false,
     "forceConsistentCasingInFileNames": false,
-    "noFallthroughCasesInSwitch": false
+    "types": ["jest"]
   }
 }


### PR DESCRIPTION
## #️⃣ 연관된 이슈

close #17 

## 📝 작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요

 - 당근 흔들기 API 구현 — 라운드별 점수 적립, 크루 점수 반영, 피버 배율 처리
   - 당근 흔들기에 대한 로그를 RDB에 저장 및 레디스에 랭킹 점수를 업데이트합니다.
 - 어뷰징 방지 로직 — 단일 요청 한계치 / 시간 조작 / 물리적 속도 한계 / 피버 상태 교차 검증
 - 스키마 도메인 분리 — carrot.schema.ts, birthday.schema.ts로 분리
 - memberId와 platform 정보는 모킹하여 로직 구현하였습니다.
 - 주석은 조금 더 추가해둘게요..!

## ✅ 테스트 / 검증 내용

> 작업 후 확인한 내용을 작성해주세요
>

- pnpm run lint 통과
- pnpm run build 통과
- pnpm run test 통과 
- 포스트맨 로컬 테스트 

## 💬 리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>

추가로 고려할만한 어뷰징 처리가 있을까요?

## 📚 참고할 만한 자료(선택)
