### PR TITLE
feat: 매숑이 출석체크 기능 구현

### DIFF
--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -3,9 +3,10 @@ import { AppController } from './app.controller';
 import { AppService } from './app.service';
 import { DbModule } from './db/db.module';
 import { RedisModule } from './redis/redis.module';
+import { MashongModule } from './mashong/mashong.module';
 
 @Module({
-  imports: [DbModule, RedisModule],
+  imports: [DbModule, RedisModule, MashongModule],
   controllers: [AppController],
   providers: [AppService],
 })

--- a/src/mashong/dto/check-attendance.response.ts
+++ b/src/mashong/dto/check-attendance.response.ts
@@ -1,0 +1,9 @@
+import { z } from 'zod';
+
+export const checkAttendanceSchema = z.object({
+  memberId: z.number().int().positive(),
+  isChecked: z.boolean(),
+  attendanceSeq: z.number().int().positive(),
+});
+
+export type CheckAttendanceResponseDto = z.infer<typeof checkAttendanceSchema>;

--- a/src/mashong/mashong.controller.ts
+++ b/src/mashong/mashong.controller.ts
@@ -1,4 +1,4 @@
-import { Controller, Get, HttpCode, Param, Post } from '@nestjs/common';
+import { Controller, HttpCode, Post } from '@nestjs/common';
 import { MashongService } from './mashong.service';
 
 @Controller('mashong')
@@ -12,12 +12,5 @@ export class MashongController {
     // const memberId = req.member.id;
     const memberId = 1; // 임시 테스트용, 가드 들어오고 삭제 예정
     return this.mashongService.checkAttendance(memberId);
-  }
-
-  @HttpCode(200)
-  @Get(':platform')
-  async getMashongInfo(@Param('platform') platform: string) {
-    const generationId = 1; // 임시 테스트용, 가드 들어오고 삭제 예정
-    return this.mashongService.getMashongInfo(platform, generationId);
   }
 }

--- a/src/mashong/mashong.controller.ts
+++ b/src/mashong/mashong.controller.ts
@@ -1,0 +1,23 @@
+import { Controller, Get, HttpCode, Param, Post } from '@nestjs/common';
+import { MashongService } from './mashong.service';
+
+@Controller('mashong')
+// TODO: AuthGuard 추가
+export class MashongController {
+  constructor(private readonly mashongService: MashongService) {}
+
+  @HttpCode(200)
+  @Post('attendance')
+  async checkAttendance() {
+    // const memberId = req.member.id;
+    const memberId = 1; // 임시 테스트용, 가드 들어오고 삭제 예정
+    return this.mashongService.checkAttendance(memberId);
+  }
+
+  @HttpCode(200)
+  @Get(':platform')
+  async getMashongInfo(@Param('platform') platform: string) {
+    const generationId = 1; // 임시 테스트용, 가드 들어오고 삭제 예정
+    return this.mashongService.getMashongInfo(platform, generationId);
+  }
+}

--- a/src/mashong/mashong.module.ts
+++ b/src/mashong/mashong.module.ts
@@ -1,0 +1,11 @@
+import { Module } from '@nestjs/common';
+import { DbModule } from '../db/db.module';
+import { MashongController } from './mashong.controller';
+import { MashongService } from './mashong.service';
+
+@Module({
+  imports: [DbModule],
+  controllers: [MashongController],
+  providers: [MashongService],
+})
+export class MashongModule {}

--- a/src/mashong/mashong.module.ts
+++ b/src/mashong/mashong.module.ts
@@ -1,11 +1,12 @@
 import { Module } from '@nestjs/common';
 import { DbModule } from '../db/db.module';
 import { MashongController } from './mashong.controller';
+import { MashongRepository } from './mashong.repository';
 import { MashongService } from './mashong.service';
 
 @Module({
   imports: [DbModule],
   controllers: [MashongController],
-  providers: [MashongService],
+  providers: [MashongRepository, MashongService],
 })
 export class MashongModule {}

--- a/src/mashong/mashong.repository.ts
+++ b/src/mashong/mashong.repository.ts
@@ -1,0 +1,38 @@
+import { Inject, Injectable } from '@nestjs/common';
+import { DRIZZLE_DB } from '../db/db.constants';
+import { NodePgDatabase } from 'drizzle-orm/node-postgres';
+import * as schema from '../schema';
+import { and, desc, eq } from 'drizzle-orm';
+import { mashongAttendance } from '../schema';
+
+@Injectable()
+export class MashongRepository {
+  constructor(
+    @Inject(DRIZZLE_DB)
+    private readonly db: NodePgDatabase<typeof schema>,
+  ) {}
+
+  async insertAttendance(memberId: number, seq: number) {
+    await this.db.insert(mashongAttendance).values({
+      memberId,
+      seq,
+    });
+  }
+
+  async getLatestAttendance(memberId: number) {
+    const today = new Date().toISOString().split('T')[0];
+
+    return this.db
+      .select()
+      .from(mashongAttendance)
+      .where(
+        and(
+          eq(mashongAttendance.memberId, memberId),
+          eq(mashongAttendance.attendanceDate, today),
+        ),
+      )
+      .orderBy(desc(mashongAttendance.seq))
+      .limit(1)
+      .then((rows) => rows[0] ?? null);
+  }
+}

--- a/src/mashong/mashong.repository.ts
+++ b/src/mashong/mashong.repository.ts
@@ -13,10 +13,14 @@ export class MashongRepository {
   ) {}
 
   async insertAttendance(memberId: number, seq: number) {
-    await this.db.insert(mashongAttendance).values({
-      memberId,
-      seq,
-    });
+    return this.db
+      .insert(mashongAttendance)
+      .values({
+        memberId,
+        seq,
+      })
+      .onConflictDoNothing()
+      .returning();
   }
 
   async getLatestAttendance(memberId: number) {

--- a/src/mashong/mashong.service.ts
+++ b/src/mashong/mashong.service.ts
@@ -1,0 +1,118 @@
+import { Inject, Injectable } from '@nestjs/common';
+import { DRIZZLE_DB } from '../db/db.constants';
+import { NodePgDatabase } from 'drizzle-orm/node-postgres';
+import * as schema from '../schema';
+import { and, desc, eq } from 'drizzle-orm';
+import { mashong, mashongAttendance } from '../schema';
+import { CheckAttendanceResponseDto } from './dto/check-attendance.response';
+import { Platform } from '../common/type/user';
+import { GetMashongInfoResponseDto } from './dto/get-mashong-info.response';
+import { MashongException } from './mashong.exception';
+
+const ATTENDANCE_INTERVAL_MS = 30 * 60 * 1000;
+
+@Injectable()
+export class MashongService {
+  constructor(
+    @Inject(DRIZZLE_DB)
+    private readonly db: NodePgDatabase<typeof schema>,
+  ) {}
+
+  /**
+   * 출석체크를 진행하는 함수
+   * @param memberId
+   */
+  async checkAttendance(memberId: number): Promise<CheckAttendanceResponseDto> {
+    // TODO: 4회 출석 완료 시 redis로 DB 조회 없이 스킵하도록 변경
+    const latestAttendance = await this.getLatestAttendance(memberId);
+    const latestSeq = latestAttendance?.seq ?? 0;
+
+    if (latestSeq >= 4) {
+      return {
+        memberId,
+        isChecked: false,
+        attendanceSeq: latestSeq,
+      };
+    }
+
+    if (latestAttendance) {
+      const afterLatestAttendanceTime =
+        Date.now() - latestAttendance.createdAt.getTime();
+      if (afterLatestAttendanceTime < ATTENDANCE_INTERVAL_MS) {
+        return {
+          memberId,
+          isChecked: false,
+          attendanceSeq: latestSeq,
+        };
+      }
+    }
+
+    const nextSeq = latestSeq + 1;
+
+    await this.db.insert(mashongAttendance).values({
+      memberId,
+      seq: nextSeq,
+    });
+
+    // TODO: 미션 기록 반영 추가, insert와 트랜잭션 처리하도록 구현
+
+    return {
+      memberId,
+      isChecked: true,
+      attendanceSeq: nextSeq,
+    };
+  }
+
+  /**
+   * 오늘의 최신 출석 기록을 조회하는 함수
+   * @param memberId
+   * @private
+   */
+  private async getLatestAttendance(memberId: number) {
+    const today = new Date().toISOString().split('T')[0];
+
+    return this.db
+      .select()
+      .from(mashongAttendance)
+      .where(
+        and(
+          eq(mashongAttendance.memberId, memberId),
+          eq(mashongAttendance.attendanceDate, today),
+        ),
+      )
+      .orderBy(desc(mashongAttendance.seq))
+      .limit(1)
+      .then((rows) => rows[0] ?? null);
+  }
+
+  async getMashongInfo(
+    platform: string,
+    generationId: number,
+  ): Promise<GetMashongInfoResponseDto> {
+    const result = await this.db
+      .select()
+      .from(mashong)
+      .where(
+        and(
+          eq(mashong.platform, Platform[platform]),
+          eq(mashong.generationId, generationId),
+        ),
+      )
+      .limit(1);
+
+    if (result.length === 0) {
+      throw MashongException.mashongNotFound();
+    }
+
+    const mashongInfo = result[0];
+
+    return {
+      id: mashongInfo.id,
+      platform: platform,
+      level: mashongInfo.level,
+      accumulatedPopcorn: mashongInfo.accumulatedPopcorn,
+      lastPopcorn: mashongInfo.lastPopcorn,
+      goalPopcorn: mashongInfo.goalPopcorn,
+    };
+  }
+}

--- a/src/mashong/mashong.service.ts
+++ b/src/mashong/mashong.service.ts
@@ -1,19 +1,12 @@
-import { Inject, Injectable } from '@nestjs/common';
-import { DRIZZLE_DB } from '../db/db.constants';
-import { NodePgDatabase } from 'drizzle-orm/node-postgres';
-import * as schema from '../schema';
-import { and, desc, eq } from 'drizzle-orm';
-import { mashongAttendance } from '../schema';
+import { Injectable } from '@nestjs/common';
 import { CheckAttendanceResponseDto } from './dto/check-attendance.response';
+import { MashongRepository } from './mashong.repository';
 
 const ATTENDANCE_INTERVAL_MS = 30 * 60 * 1000;
 
 @Injectable()
 export class MashongService {
-  constructor(
-    @Inject(DRIZZLE_DB)
-    private readonly db: NodePgDatabase<typeof schema>,
-  ) {}
+  constructor(private readonly mashongRepository: MashongRepository) {}
 
   /**
    * 출석체크를 진행하는 함수
@@ -21,7 +14,8 @@ export class MashongService {
    */
   async checkAttendance(memberId: number): Promise<CheckAttendanceResponseDto> {
     // TODO: 4회 출석 완료 시 redis로 DB 조회 없이 스킵하도록 변경
-    const latestAttendance = await this.getLatestAttendance(memberId);
+    const latestAttendance =
+      await this.mashongRepository.getLatestAttendance(memberId);
     const latestSeq = latestAttendance?.seq ?? 0;
 
     if (latestSeq >= 4) {
@@ -46,10 +40,7 @@ export class MashongService {
 
     const nextSeq = latestSeq + 1;
 
-    await this.db.insert(mashongAttendance).values({
-      memberId,
-      seq: nextSeq,
-    });
+    await this.mashongRepository.insertAttendance(memberId, nextSeq);
 
     // TODO: 미션 기록 반영 추가, insert와 트랜잭션 처리하도록 구현
 
@@ -58,27 +49,5 @@ export class MashongService {
       isChecked: true,
       attendanceSeq: nextSeq,
     };
-  }
-
-  /**
-   * 오늘의 최신 출석 기록을 조회하는 함수
-   * @param memberId
-   * @private
-   */
-  private async getLatestAttendance(memberId: number) {
-    const today = new Date().toISOString().split('T')[0];
-
-    return this.db
-      .select()
-      .from(mashongAttendance)
-      .where(
-        and(
-          eq(mashongAttendance.memberId, memberId),
-          eq(mashongAttendance.attendanceDate, today),
-        ),
-      )
-      .orderBy(desc(mashongAttendance.seq))
-      .limit(1)
-      .then((rows) => rows[0] ?? null);
   }
 }

--- a/src/mashong/mashong.service.ts
+++ b/src/mashong/mashong.service.ts
@@ -3,11 +3,8 @@ import { DRIZZLE_DB } from '../db/db.constants';
 import { NodePgDatabase } from 'drizzle-orm/node-postgres';
 import * as schema from '../schema';
 import { and, desc, eq } from 'drizzle-orm';
-import { mashong, mashongAttendance } from '../schema';
+import { mashongAttendance } from '../schema';
 import { CheckAttendanceResponseDto } from './dto/check-attendance.response';
-import { Platform } from '../common/type/user';
-import { GetMashongInfoResponseDto } from './dto/get-mashong-info.response';
-import { MashongException } from './mashong.exception';
 
 const ATTENDANCE_INTERVAL_MS = 30 * 60 * 1000;
 
@@ -83,36 +80,5 @@ export class MashongService {
       .orderBy(desc(mashongAttendance.seq))
       .limit(1)
       .then((rows) => rows[0] ?? null);
-  }
-
-  async getMashongInfo(
-    platform: string,
-    generationId: number,
-  ): Promise<GetMashongInfoResponseDto> {
-    const result = await this.db
-      .select()
-      .from(mashong)
-      .where(
-        and(
-          eq(mashong.platform, Platform[platform]),
-          eq(mashong.generationId, generationId),
-        ),
-      )
-      .limit(1);
-
-    if (result.length === 0) {
-      throw MashongException.mashongNotFound();
-    }
-
-    const mashongInfo = result[0];
-
-    return {
-      id: mashongInfo.id,
-      platform: platform,
-      level: mashongInfo.level,
-      accumulatedPopcorn: mashongInfo.accumulatedPopcorn,
-      lastPopcorn: mashongInfo.lastPopcorn,
-      goalPopcorn: mashongInfo.goalPopcorn,
-    };
   }
 }

--- a/src/mashong/mashong.service.ts
+++ b/src/mashong/mashong.service.ts
@@ -40,14 +40,19 @@ export class MashongService {
 
     const nextSeq = latestSeq + 1;
 
-    await this.mashongRepository.insertAttendance(memberId, nextSeq);
+    const insertResult = await this.mashongRepository.insertAttendance(
+      memberId,
+      nextSeq,
+    );
 
     // TODO: 미션 기록 반영 추가, insert와 트랜잭션 처리하도록 구현
 
+    const inserted = insertResult.length > 0;
+
     return {
       memberId,
-      isChecked: true,
-      attendanceSeq: nextSeq,
+      isChecked: inserted,
+      attendanceSeq: inserted ? nextSeq : latestSeq,
     };
   }
 }

--- a/src/schema/schema.ts
+++ b/src/schema/schema.ts
@@ -545,6 +545,30 @@ export const birthdayCards = pgTable(
   ],
 );
 
+export const mashongAttendance = pgTable(
+  'mashong_attendance',
+  {
+    id: bigserial('id', { mode: 'number' }).primaryKey(),
+    memberId: bigint('member_id', { mode: 'number' })
+      .notNull()
+      .references(() => members.id, { onDelete: 'cascade' }),
+    seq: integer('seq').notNull(),
+    attendanceDate: date('attendance_date', { mode: 'string' })
+      .notNull()
+      .default(sql`CURRENT_DATE`),
+    createdAt: timestamp('created_at', { withTimezone: true })
+      .notNull()
+      .defaultNow(),
+  },
+  (table) => [
+    unique('mashong_attendance_member_date_seq_uq').on(
+      table.memberId,
+      table.attendanceDate,
+      table.seq,
+    ),
+  ],
+);
+
 export const membersRelations = relations(members, ({ one, many }) => ({
   profile: one(memberProfiles, {
     fields: [members.id],

--- a/src/schema/schema.ts
+++ b/src/schema/schema.ts
@@ -586,6 +586,7 @@ export const membersRelations = relations(members, ({ one, many }) => ({
     relationName: 'birthday_receiver',
   }),
   uploadedImages: many(images),
+  mashongAttendance: many(mashongAttendance),
 }));
 
 export const memberProfilesRelations = relations(memberProfiles, ({ one }) => ({


### PR DESCRIPTION
## #️⃣ 연관된 이슈

close #28 

## 📝 작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요

매숑이 출석체크 기능을 추가합니다.
매숑이 출석체크는 30분마다 가능하며 하루 4번까지 가능합니다.

## ✅ 테스트 / 검증 내용

> 작업 후 확인한 내용을 작성해주세요
>
> ex) lint 통과, type check 통과, 로컬 API 동작 확인

lint 통과했으나 PR 쪼개는 과정에서 테스트 실패 가능성 있어 수정 필요
로컬 API 동작 확인
앱 연동 테스트는 아직 진행 전

## 📸 스크린샷 (선택)

## 💬 리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
- 일단 db:generate는 머지쯤에 생성하려고 뺐어요 (변경사항 너무 많이 잡힘 & 타 PR과 충돌 우려)
- 시간 관련해서는 배포 타임존을 KST로 잡아보려고 해서 별도 처리는 하지 않았어요
- 가드 붙는거에 따라 추가 수정해야 합니다 / DTO 스타일은 윤하 OAuth 랑 맞췄어용
- 출석 테이블 자체에 매숑이 id를 넣는게 맞을까요? -> 팝콘 부여는 매숑이 id를 포함시킬텐데 출석도 그렇게 하는게 더 좋을지?

## 📚 참고할 만한 자료(선택)
