### PR TITLE
feat: 당근 피버 확률 생성 API 구현

### DIFF
--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -3,9 +3,10 @@ import { AppController } from './app.controller';
 import { AppService } from './app.service';
 import { DbModule } from './db/db.module';
 import { RedisModule } from './redis/redis.module';
+import { DanggnsModule } from './danggn/danggns.module';
 
 @Module({
-  imports: [DbModule, RedisModule],
+  imports: [DbModule, RedisModule, DanggnsModule],
   controllers: [AppController],
   providers: [AppService],
 })

--- a/src/danggn/danggns-cache.repository.ts
+++ b/src/danggn/danggns-cache.repository.ts
@@ -1,0 +1,66 @@
+import { Inject, Injectable } from '@nestjs/common';
+import Redis from 'ioredis';
+import { REDIS_CLIENT } from '../redis/redis.constants';
+
+const LAST_SENT_AT_TTL_SECONDS = 60;
+const FEVER_REDIS_TTL_SECONDS = 7;
+const FEVER_COOLTIME_TTL_SECONDS = 10;
+
+@Injectable()
+export class DanggnsCacheRepository {
+  constructor(@Inject(REDIS_CLIENT) private readonly redisClient: Redis) {}
+
+  private getFeverKey(memberId: number) {
+    return `danggns:member:${memberId}:fever`;
+  }
+
+  private getFeverCooltimeKey(memberId: number) {
+    return `danggns:member:${memberId}:feverCooltime`;
+  }
+
+  private getLastSentAtKey(memberId: number) {
+    return `danggns:member:${memberId}:lastSentAt`;
+  }
+
+  async exists(memberId: number): Promise<boolean> {
+    const key = this.getFeverKey(memberId);
+    return (await this.redisClient.exists(key)) === 1;
+  }
+
+  async getLastSentAt(memberId: number): Promise<number | null> {
+    const value = await this.redisClient.get(this.getLastSentAtKey(memberId));
+    return value !== null ? Number(value) : null;
+  }
+
+  async setLastSentAt(memberId: number, timestamp: number): Promise<void> {
+    await this.redisClient.set(
+      this.getLastSentAtKey(memberId),
+      timestamp,
+      'EX',
+      LAST_SENT_AT_TTL_SECONDS,
+    );
+  }
+
+  async setFever(memberId: number): Promise<void> {
+    await this.redisClient.set(
+      this.getFeverKey(memberId),
+      '1',
+      'EX',
+      FEVER_REDIS_TTL_SECONDS,
+    );
+  }
+
+  async getFeverCooltimeRemaining(memberId: number): Promise<number> {
+    const ttl = await this.redisClient.ttl(this.getFeverCooltimeKey(memberId));
+    return ttl > 0 ? ttl : 0;
+  }
+
+  async setFeverCooltime(memberId: number): Promise<void> {
+    await this.redisClient.set(
+      this.getFeverCooltimeKey(memberId),
+      '1',
+      'EX',
+      FEVER_COOLTIME_TTL_SECONDS,
+    );
+  }
+}

--- a/src/danggn/danggns.controller.ts
+++ b/src/danggn/danggns.controller.ts
@@ -1,0 +1,20 @@
+import { Body, Controller, Post } from '@nestjs/common';
+import { ZodValidationPipe } from '../common/pipes/zod-validation.pipe';
+import {
+  DanggnsFeverRequestDto,
+  DanggnsFeverRequestSchema,
+} from './dto/danggns-fever-request.dto';
+import { DanggnsService } from './danggns.service';
+
+@Controller('danggns')
+export class DanggnsController {
+  constructor(private readonly danggnsService: DanggnsService) {}
+
+  @Post('fevers')
+  createFever(
+    @Body(new ZodValidationPipe(DanggnsFeverRequestSchema))
+    body: DanggnsFeverRequestDto,
+  ) {
+    return this.danggnsService.handleFever(body.roundId);
+  }
+}

--- a/src/danggn/danggns.exception.ts
+++ b/src/danggn/danggns.exception.ts
@@ -1,0 +1,32 @@
+import { HttpStatus } from '@nestjs/common';
+import { BaseException } from '../common/exception/base.exception';
+
+export class DanggnsException extends BaseException {
+  private constructor(status: number, errorCode: string, message: string) {
+    super(status, errorCode, message);
+  }
+
+  static roundClosed() {
+    return new DanggnsException(
+      HttpStatus.FORBIDDEN,
+      'ROUND_CLOSED',
+      '해당 회차는 이미 종료되었습니다.',
+    );
+  }
+
+  static roundNotFound() {
+    return new DanggnsException(
+      HttpStatus.NOT_FOUND,
+      'ROUND_NOT_FOUND',
+      '해당 회차 정보를 찾을 수 없습니다.',
+    );
+  }
+
+  static feverNotActive() {
+    return new DanggnsException(
+      HttpStatus.FORBIDDEN,
+      'FEVER_NOT_ACTIVE',
+      '현재 피버 상태가 아닙니다.',
+    );
+  }
+}

--- a/src/danggn/danggns.module.ts
+++ b/src/danggn/danggns.module.ts
@@ -1,0 +1,12 @@
+import { Module } from '@nestjs/common';
+
+import { DanggnsCacheRepository } from './danggns-cache.repository';
+import { DanggnsController } from './danggns.controller';
+import { DanggnsRepository } from './danggns.repository';
+import { DanggnsService } from './danggns.service';
+
+@Module({
+  controllers: [DanggnsController],
+  providers: [DanggnsService, DanggnsRepository, DanggnsCacheRepository],
+})
+export class DanggnsModule {}

--- a/src/danggn/danggns.repository.ts
+++ b/src/danggn/danggns.repository.ts
@@ -1,0 +1,39 @@
+import { Inject, Injectable } from '@nestjs/common';
+import { eq } from 'drizzle-orm';
+import type { NodePgDatabase } from 'drizzle-orm/node-postgres';
+
+import * as schema from '../schema';
+import { DRIZZLE_DB } from '../db/db.constants';
+
+export type DanggnsRound = typeof schema.carrotRounds.$inferSelect;
+
+export type DanggnsShakeEventInsert = {
+  roundId: number;
+  memberId: number;
+  scoreDelta: number;
+};
+
+@Injectable()
+export class DanggnsRepository {
+  constructor(
+    @Inject(DRIZZLE_DB)
+    private readonly db: NodePgDatabase<typeof schema>,
+  ) {}
+
+  async findRoundById(roundId: number): Promise<DanggnsRound | undefined> {
+    const [row] = await this.db
+      .select()
+      .from(schema.carrotRounds)
+      .where(eq(schema.carrotRounds.id, roundId))
+      .limit(1);
+    return row;
+  }
+
+  async insertShakeEvent(input: DanggnsShakeEventInsert): Promise<void> {
+    await this.db.insert(schema.carrotShakeEvents).values({
+      roundId: input.roundId,
+      memberId: input.memberId,
+      scoreDelta: input.scoreDelta,
+    });
+  }
+}

--- a/src/danggn/danggns.service.spec.ts
+++ b/src/danggn/danggns.service.spec.ts
@@ -1,0 +1,123 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { DanggnsService } from './danggns.service';
+import { DanggnsRepository } from './danggns.repository';
+import { DanggnsCacheRepository } from './danggns-cache.repository';
+import { DanggnsException } from './danggns.exception';
+
+const MOCK_ROUND = {
+  id: 1,
+  generationId: 1,
+  roundNo: 1,
+  startedAt: new Date('2020-01-01'),
+  endedAt: new Date('2099-01-01'),
+  createdAt: new Date(),
+  updatedAt: new Date(),
+};
+
+describe('DanggnsService', () => {
+  let service: DanggnsService;
+  let danggnsRepository: jest.Mocked<DanggnsRepository>;
+  let danggnsCacheRepository: jest.Mocked<DanggnsCacheRepository>;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        DanggnsService,
+        {
+          provide: DanggnsRepository,
+          useValue: {
+            findRoundById: jest.fn(),
+          },
+        },
+        {
+          provide: DanggnsCacheRepository,
+          useValue: {
+            exists: jest.fn(),
+            getFeverCooltimeRemaining: jest.fn(),
+            setFever: jest.fn(),
+            setFeverCooltime: jest.fn(),
+          },
+        },
+      ],
+    }).compile();
+
+    service = module.get(DanggnsService);
+    danggnsRepository = module.get(DanggnsRepository);
+    danggnsCacheRepository = module.get(DanggnsCacheRepository);
+
+    danggnsRepository.findRoundById.mockResolvedValue(MOCK_ROUND);
+    danggnsCacheRepository.exists.mockResolvedValue(false);
+    danggnsCacheRepository.getFeverCooltimeRemaining.mockResolvedValue(0);
+    danggnsCacheRepository.setFever.mockResolvedValue(undefined);
+    danggnsCacheRepository.setFeverCooltime.mockResolvedValue(undefined);
+  });
+
+  describe('handleFever', () => {
+    const ROUND_ID = 1;
+
+    it('라운드가 없으면 ROUND_NOT_FOUND 예외를 던진다', async () => {
+      danggnsRepository.findRoundById.mockResolvedValue(undefined);
+
+      const err = await service.handleFever(ROUND_ID).catch((e) => e);
+
+      expect(err).toBeInstanceOf(DanggnsException);
+      expect(err.getResponse()).toMatchObject({ errorCode: 'ROUND_NOT_FOUND' });
+    });
+
+    it('이미 피버 키가 있으면 확률·재설정 없이 거부하고 쿨타임만 반환한다', async () => {
+      danggnsCacheRepository.exists.mockResolvedValue(true);
+      danggnsCacheRepository.getFeverCooltimeRemaining.mockResolvedValue(12);
+
+      const result = await service.handleFever(ROUND_ID);
+
+      expect(result).toEqual({
+        isFeverAllowed: false,
+        remainingCooltime: 12,
+      });
+      expect(danggnsCacheRepository.setFever).not.toHaveBeenCalled();
+      expect(danggnsCacheRepository.setFeverCooltime).not.toHaveBeenCalled();
+    });
+
+    it('쿨타임이 남아 있으면 거부한다', async () => {
+      danggnsCacheRepository.getFeverCooltimeRemaining.mockResolvedValue(7);
+
+      const result = await service.handleFever(ROUND_ID);
+
+      expect(result).toEqual({
+        isFeverAllowed: false,
+        remainingCooltime: 7,
+      });
+      expect(danggnsCacheRepository.setFever).not.toHaveBeenCalled();
+    });
+
+    it('확률 성공 시 피버와 쿨타임을 설정한다', async () => {
+      const randomSpy = jest.spyOn(Math, 'random').mockReturnValue(0);
+
+      const result = await service.handleFever(ROUND_ID);
+
+      expect(result).toEqual({ isFeverAllowed: true, remainingCooltime: 0 });
+      expect(danggnsCacheRepository.setFever).toHaveBeenCalledWith(1);
+      expect(danggnsCacheRepository.setFeverCooltime).toHaveBeenCalledWith(1);
+
+      randomSpy.mockRestore();
+    });
+
+    it('확률 실패 시 쿨타임만 설정하고 Redis TTL 기준 남은 시간을 반환한다', async () => {
+      const randomSpy = jest.spyOn(Math, 'random').mockReturnValue(0.99);
+      danggnsCacheRepository.getFeverCooltimeRemaining
+        .mockResolvedValueOnce(0)
+        .mockResolvedValueOnce(14);
+
+      const result = await service.handleFever(ROUND_ID);
+
+      expect(result).toEqual({
+        isFeverAllowed: false,
+        remainingCooltime: 14,
+      });
+      expect(danggnsCacheRepository.setFever).not.toHaveBeenCalled();
+      expect(danggnsCacheRepository.setFeverCooltime).toHaveBeenCalledWith(1);
+
+      randomSpy.mockRestore();
+    });
+  });
+});

--- a/src/danggn/danggns.service.ts
+++ b/src/danggn/danggns.service.ts
@@ -1,0 +1,69 @@
+import { Injectable } from '@nestjs/common';
+import { DanggnsException } from './danggns.exception';
+import { DanggnsRepository } from './danggns.repository';
+import { DanggnsCacheRepository } from './danggns-cache.repository';
+
+export type DanggnsFeverResponseDto = {
+  isFeverAllowed: boolean;
+  remainingCooltime: number;
+};
+
+const MOCK_USER_ID = 1;
+const FEVER_PROBABILITY = 0.1;
+
+@Injectable()
+export class DanggnsService {
+  constructor(
+    private readonly danggnsRepository: DanggnsRepository,
+    private readonly danggnsCacheRepository: DanggnsCacheRepository,
+  ) {}
+
+  async handleFever(roundId: number): Promise<DanggnsFeverResponseDto> {
+    const round = await this.findRoundByIdOrThrow(roundId);
+
+    const now = new Date();
+    if (now < round.startedAt || now > round.endedAt) {
+      throw DanggnsException.roundClosed();
+    }
+
+    // 중복 진입 제한: 이미 피버라면 연장/재발생 없이 그대로 거부
+    const feverActive = await this.danggnsCacheRepository.exists(MOCK_USER_ID);
+    if (feverActive) {
+      const remainingCooltime =
+        await this.danggnsCacheRepository.getFeverCooltimeRemaining(
+          MOCK_USER_ID,
+        );
+      return { isFeverAllowed: false, remainingCooltime };
+    }
+
+    // 쿨타임 제한
+    const remainingCooltime =
+      await this.danggnsCacheRepository.getFeverCooltimeRemaining(MOCK_USER_ID);
+    if (remainingCooltime > 0) {
+      return { isFeverAllowed: false, remainingCooltime };
+    }
+
+    const isFeverAllowed = Math.random() < FEVER_PROBABILITY;
+    if (isFeverAllowed) {
+      await Promise.all([
+        this.danggnsCacheRepository.setFever(MOCK_USER_ID),
+        this.danggnsCacheRepository.setFeverCooltime(MOCK_USER_ID),
+      ]);
+      return { isFeverAllowed: true, remainingCooltime: 0 };
+    }
+
+    // 확률 실패 시에도 쿨타임 부여 (재시도 스팸 방지)
+    await this.danggnsCacheRepository.setFeverCooltime(MOCK_USER_ID);
+    const coolAfter =
+      await this.danggnsCacheRepository.getFeverCooltimeRemaining(MOCK_USER_ID);
+    return { isFeverAllowed: false, remainingCooltime: coolAfter };
+  }
+
+  private async findRoundByIdOrThrow(roundId: number) {
+    const round = await this.danggnsRepository.findRoundById(roundId);
+    if (!round) {
+      throw DanggnsException.roundNotFound();
+    }
+    return round;
+  }
+}

--- a/src/danggn/dto/danggns-fever-request.dto.ts
+++ b/src/danggn/dto/danggns-fever-request.dto.ts
@@ -1,0 +1,7 @@
+import { z } from 'zod';
+
+export const DanggnsFeverRequestSchema = z.object({
+  roundId: z.number().int().positive(),
+});
+
+export type DanggnsFeverRequestDto = z.infer<typeof DanggnsFeverRequestSchema>;


### PR DESCRIPTION
## #️⃣ 연관된 이슈

close #18 

## 📝 작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요

가중치에 따라 피버 확률을 생성하고 검증을 위해 레디스에 저장합니다.
피버 검증은 당근 흔들기에서 수행합니다. #34
또한 쿨다운 타임을 주어 피버타임이 무한정 지속되는 것을 막습니다.

## ✅ 테스트 / 검증 내용

> 작업 후 확인한 내용을 작성해주세요
>

build, lint, test 통과
포스트맨으로 로컬에서 테스트 완료

## 💬 리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>

피버타임은 3초인데, 검증 ttl은 조금 더 여유롭게 두었습니다.
피버 확률에서 false가 나오는 경우에도 스팸 방지를 위해 쿨타임을 두고는 있는데, 실패/성공에 대한 쿨타임 ttl을 다르게 두는 건 어떤가 싶어요

## 📚 참고할 만한 자료(선택)
