### PR TITLE
feat: 당근 흔들기 랭킹 회차 목록 조회 API 구현

### DIFF
--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -1,11 +1,12 @@
 import { Module } from '@nestjs/common';
 import { AppController } from './app.controller';
 import { AppService } from './app.service';
+import { DanggnsModule } from './danggn/danggns.module';
 import { DbModule } from './db/db.module';
 import { RedisModule } from './redis/redis.module';
 
 @Module({
-  imports: [DbModule, RedisModule],
+  imports: [DbModule, RedisModule, DanggnsModule],
   controllers: [AppController],
   providers: [AppService],
 })

--- a/src/danggn/danggns.controller.ts
+++ b/src/danggn/danggns.controller.ts
@@ -1,0 +1,12 @@
+import { Controller, Get } from '@nestjs/common';
+import { DanggnsService } from './danggns.service';
+
+@Controller('danggns')
+export class DanggnsController {
+  constructor(private readonly danggnsService: DanggnsService) {}
+
+  @Get('rounds')
+  getRounds() {
+    return this.danggnsService.getRounds();
+  }
+}

--- a/src/danggn/danggns.module.ts
+++ b/src/danggn/danggns.module.ts
@@ -1,0 +1,10 @@
+import { Module } from '@nestjs/common';
+import { DanggnsController } from './danggns.controller';
+import { DanggnsRepository } from './danggns.repository';
+import { DanggnsService } from './danggns.service';
+
+@Module({
+  controllers: [DanggnsController],
+  providers: [DanggnsService, DanggnsRepository],
+})
+export class DanggnsModule {}

--- a/src/danggn/danggns.repository.ts
+++ b/src/danggn/danggns.repository.ts
@@ -1,0 +1,29 @@
+import { Inject, Injectable } from '@nestjs/common';
+import { and, eq } from 'drizzle-orm';
+import type { NodePgDatabase } from 'drizzle-orm/node-postgres';
+import { DRIZZLE_DB } from '../db/db.constants';
+import * as schema from '../schema';
+
+@Injectable()
+export class DanggnsRepository {
+  constructor(
+    @Inject(DRIZZLE_DB) private readonly db: NodePgDatabase<typeof schema>,
+  ) {}
+
+  findActiveGenerationByMemberId(memberId: number) {
+    return this.db.query.memberGenerationActivities.findFirst({
+      where: and(
+        eq(schema.memberGenerationActivities.memberId, memberId),
+        eq(schema.memberGenerationActivities.status, 'ACTIVE'),
+      ),
+    });
+  }
+
+  findRecentRoundsByGenerationId(generationId: number, limit: number) {
+    return this.db.query.carrotRounds.findMany({
+      where: eq(schema.carrotRounds.generationId, generationId),
+      orderBy: (rounds, { desc }) => [desc(rounds.roundNo)],
+      limit,
+    });
+  }
+}

--- a/src/danggn/danggns.service.ts
+++ b/src/danggn/danggns.service.ts
@@ -1,0 +1,53 @@
+import { Injectable } from '@nestjs/common';
+import { DanggnsRepository } from './danggns.repository';
+
+type RoundStatus = 'IN_PROGRESS' | 'ENDED' | 'UPCOMING';
+
+export type DanggnsRoundsResponseDto = {
+  roundId: number;
+  roundNo: number;
+  status: RoundStatus;
+  startedAt: string;
+  endedAt: string;
+}[];
+
+// TODO: 인증 구현 후 토큰에서 추출한 실제 유저 ID로 교체
+const MOCK_USER_ID = 1;
+const MOCK_GENERATION_ID = 2;
+
+@Injectable()
+export class DanggnsService {
+  constructor(private readonly danggnsRepository: DanggnsRepository) {}
+
+  async getRounds(): Promise<DanggnsRoundsResponseDto> {
+    const activity =
+      await this.danggnsRepository.findActiveGenerationByMemberId(MOCK_USER_ID);
+    if (!activity) {
+      return [];
+    }
+
+    const rounds = await this.danggnsRepository.findRecentRoundsByGenerationId(
+      MOCK_GENERATION_ID,
+      15,
+    );
+    const now = new Date();
+
+    return rounds.map((round) => ({
+      roundId: round.id,
+      roundNo: round.roundNo,
+      status: this.computeRoundStatus(now, round.startedAt, round.endedAt),
+      startedAt: round.startedAt.toISOString(),
+      endedAt: round.endedAt.toISOString(),
+    }));
+  }
+
+  private computeRoundStatus(
+    now: Date,
+    startedAt: Date,
+    endedAt: Date,
+  ): RoundStatus {
+    if (now < startedAt) return 'UPCOMING';
+    if (now > endedAt) return 'ENDED';
+    return 'IN_PROGRESS';
+  }
+}

--- a/src/db/seed.danggn-rounds.ts
+++ b/src/db/seed.danggn-rounds.ts
@@ -1,0 +1,72 @@
+import 'dotenv/config';
+
+import { eq } from 'drizzle-orm';
+import * as schema from '../schema';
+import { createDb, createPool } from './client';
+
+const databaseUrl = process.env.DATABASE_URL;
+if (!databaseUrl) throw new Error('DATABASE_URL is required to run seed.');
+
+const pool = createPool(databaseUrl);
+const db = createDb(pool);
+
+const ROUND_COUNT = 20;
+const ROUND_DURATION_MS = 14 * 24 * 60 * 60 * 1000;
+
+async function seed() {
+  const now = new Date();
+
+  // 마지막 회차(roundNo=20)가 실행 시점 기준 IN_PROGRESS가 되도록 역산
+  const lastRoundEnd = new Date(now.getTime() + 7 * 24 * 60 * 60 * 1000);
+  const lastRoundStart = new Date(lastRoundEnd.getTime() - ROUND_DURATION_MS);
+  const firstRoundStart = new Date(
+    lastRoundStart.getTime() - (ROUND_COUNT - 1) * ROUND_DURATION_MS,
+  );
+  const genEnd = new Date(lastRoundEnd.getTime() + ROUND_DURATION_MS);
+
+  // 시드 전용 기수 (number=999)
+  const [inserted] = await db
+    .insert(schema.generations)
+    .values({
+      number: 999,
+      startedAt: firstRoundStart,
+      endedAt: genEnd,
+      status: 'ACTIVE',
+    })
+    .onConflictDoNothing()
+    .returning();
+
+  const generationId =
+    inserted?.id ??
+    (await db.query.generations.findFirst({
+      where: eq(schema.generations.number, 999),
+    }))!.id;
+
+  const rounds = Array.from({ length: ROUND_COUNT }, (_, i) => {
+    const startedAt = new Date(
+      firstRoundStart.getTime() + i * ROUND_DURATION_MS,
+    );
+    const endedAt = new Date(startedAt.getTime() + ROUND_DURATION_MS);
+    return { generationId, roundNo: i + 1, startedAt, endedAt };
+  });
+
+  const result = await db
+    .insert(schema.carrotRounds)
+    .values(rounds)
+    .onConflictDoNothing()
+    .returning();
+
+  console.log(
+    `Generation id=${generationId} (number=999) 에 ${result.length}개 회차 시드 완료`,
+  );
+  console.log(
+    `현재 회차: roundNo=${ROUND_COUNT} | ${lastRoundStart.toISOString()} ~ ${lastRoundEnd.toISOString()}`,
+  );
+}
+
+seed()
+  .catch((err) => {
+    console.error(err);
+    process.exit(1);
+  })
+  .finally(() => pool.end());


### PR DESCRIPTION
## #️⃣ 연관된 이슈

close #40 

## 📝 작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요

- 랭킹 회차 목록 조회 기능을 구현하였습니다.
- 2주 단위의 20개 round 정보를 시딩하는 코드도 같이 작성하였습니다.
- 개수도 많지 않고, roundNo / generationId에 대한 unique 인덱스가 잘 걸려있어서 조회 상의 문제도 크게 없어보입니다.

## ✅ 테스트 / 검증 내용

> 작업 후 확인한 내용을 작성해주세요
>
lint 통과, build 통과, 로컬 API 동작 확인

## 💬 리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?

## 📚 참고할 만한 자료(선택)
