### PR TITLE
feat: 당근 회차 별 랭킹 조회 API 구현

### DIFF
--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -2,10 +2,11 @@ import { Module } from '@nestjs/common';
 import { AppController } from './app.controller';
 import { AppService } from './app.service';
 import { DbModule } from './db/db.module';
+import { DanggnsModule } from './danggn/danggns.module';
 import { RedisModule } from './redis/redis.module';
 
 @Module({
-  imports: [DbModule, RedisModule],
+  imports: [DbModule, RedisModule, DanggnsModule],
   controllers: [AppController],
   providers: [AppService],
 })

--- a/src/danggn/danggns-cache.repository.ts
+++ b/src/danggn/danggns-cache.repository.ts
@@ -1,0 +1,29 @@
+import { Inject, Injectable } from '@nestjs/common';
+import Redis from 'ioredis';
+import { REDIS_CLIENT } from '../redis/redis.constants';
+
+const RANKING_RESTORED_TTL_SECONDS = 30;
+
+@Injectable()
+export class DanggnsCacheRepository {
+  constructor(@Inject(REDIS_CLIENT) private readonly redisClient: Redis) {}
+
+  private getRankingRestoredKey(roundId: number) {
+    return `danggns:round:${roundId}:ranking:restored`;
+  }
+
+  async isRankingRestored(roundId: number): Promise<boolean> {
+    return (
+      (await this.redisClient.exists(this.getRankingRestoredKey(roundId))) === 1
+    );
+  }
+
+  async setRankingRestored(roundId: number): Promise<void> {
+    await this.redisClient.set(
+      this.getRankingRestoredKey(roundId),
+      '1',
+      'EX',
+      RANKING_RESTORED_TTL_SECONDS,
+    );
+  }
+}

--- a/src/danggn/danggns.controller.ts
+++ b/src/danggn/danggns.controller.ts
@@ -1,0 +1,12 @@
+import { Controller, Get, Param, ParseIntPipe } from '@nestjs/common';
+import { DanggnsService } from './danggns.service';
+
+@Controller('danggns')
+export class DanggnsController {
+  constructor(private readonly danggnsService: DanggnsService) {}
+
+  @Get('rounds/:roundId')
+  getRound(@Param('roundId', ParseIntPipe) roundId: number) {
+    return this.danggnsService.getRoundData(roundId);
+  }
+}

--- a/src/danggn/danggns.exception.ts
+++ b/src/danggn/danggns.exception.ts
@@ -1,0 +1,16 @@
+import { HttpStatus } from '@nestjs/common';
+import { BaseException } from '../common/exception/base.exception';
+
+export class DanggnsException extends BaseException {
+  private constructor(status: number, errorCode: string, message: string) {
+    super(status, errorCode, message);
+  }
+
+  static roundNotFound() {
+    return new DanggnsException(
+      HttpStatus.NOT_FOUND,
+      'ROUND_NOT_FOUND',
+      '해당 회차 정보를 찾을 수 없습니다.',
+    );
+  }
+}

--- a/src/danggn/danggns.module.ts
+++ b/src/danggn/danggns.module.ts
@@ -1,0 +1,17 @@
+import { Module } from '@nestjs/common';
+import { DanggnsController } from './danggns.controller';
+import { RankingRepository } from './ranking.repository';
+import { DanggnsRepository } from './danggns.repository';
+import { DanggnsService } from './danggns.service';
+import { DanggnsCacheRepository } from './danggns-cache.repository';
+
+@Module({
+  controllers: [DanggnsController],
+  providers: [
+    RankingRepository,
+    DanggnsRepository,
+    DanggnsCacheRepository,
+    DanggnsService,
+  ],
+})
+export class DanggnsModule {}

--- a/src/danggn/danggns.repository.ts
+++ b/src/danggn/danggns.repository.ts
@@ -1,0 +1,102 @@
+import { Inject, Injectable } from '@nestjs/common';
+import { and, eq, inArray, sql } from 'drizzle-orm';
+import type { NodePgDatabase } from 'drizzle-orm/node-postgres';
+import { DRIZZLE_DB } from '../db/db.constants';
+import * as schema from '../schema';
+
+@Injectable()
+export class DanggnsRepository {
+  constructor(
+    @Inject(DRIZZLE_DB) private readonly db: NodePgDatabase<typeof schema>,
+  ) {}
+
+  findRoundById(roundId: number) {
+    return this.db.query.carrotRounds.findFirst({
+      where: eq(schema.carrotRounds.id, roundId),
+    });
+  }
+
+  findMembersByIds(memberIds: number[]) {
+    if (memberIds.length === 0) return Promise.resolve([]);
+    return this.db
+      .select({ id: schema.members.id, name: schema.members.name })
+      .from(schema.members)
+      .where(inArray(schema.members.id, memberIds));
+  }
+
+  findRoundRankings(
+    roundId: number,
+  ): Promise<{ memberId: number; finalRank: number; finalScore: number }[]> {
+    return this.db
+      .select({
+        memberId: schema.carrotRoundRankings.memberId,
+        finalRank: schema.carrotRoundRankings.finalRank,
+        finalScore: schema.carrotRoundRankings.finalScore,
+      })
+      .from(schema.carrotRoundRankings)
+      .where(eq(schema.carrotRoundRankings.roundId, roundId))
+      .orderBy(schema.carrotRoundRankings.finalRank);
+  }
+
+  aggregatePlatformScoresBySnapshot(
+    roundId: number,
+    generationId: number,
+  ): Promise<{ platform: string; totalScore: number }[]> {
+    return this.db
+      .select({
+        platform: schema.memberGenerationActivities.platform,
+        totalScore: sql<number>`cast(sum(${schema.carrotRoundRankings.finalScore}) as integer)`,
+      })
+      .from(schema.carrotRoundRankings)
+      .innerJoin(
+        schema.memberGenerationActivities,
+        and(
+          eq(
+            schema.carrotRoundRankings.memberId,
+            schema.memberGenerationActivities.memberId,
+          ),
+          eq(schema.memberGenerationActivities.generationId, generationId),
+        ),
+      )
+      .where(eq(schema.carrotRoundRankings.roundId, roundId))
+      .groupBy(schema.memberGenerationActivities.platform)
+      .orderBy(sql`sum(${schema.carrotRoundRankings.finalScore}) desc`);
+  }
+
+  aggregateShakeScoresByMember(
+    roundId: number,
+  ): Promise<{ memberId: number; totalScore: number }[]> {
+    return this.db
+      .select({
+        memberId: schema.carrotShakeEvents.memberId,
+        totalScore: sql<number>`cast(sum(${schema.carrotShakeEvents.scoreDelta}) as integer)`,
+      })
+      .from(schema.carrotShakeEvents)
+      .where(eq(schema.carrotShakeEvents.roundId, roundId))
+      .groupBy(schema.carrotShakeEvents.memberId);
+  }
+
+  aggregateShakeScoresByPlatform(
+    roundId: number,
+    generationId: number,
+  ): Promise<{ platform: string; totalScore: number }[]> {
+    return this.db
+      .select({
+        platform: schema.memberGenerationActivities.platform,
+        totalScore: sql<number>`cast(sum(${schema.carrotShakeEvents.scoreDelta}) as integer)`,
+      })
+      .from(schema.carrotShakeEvents)
+      .innerJoin(
+        schema.memberGenerationActivities,
+        and(
+          eq(
+            schema.carrotShakeEvents.memberId,
+            schema.memberGenerationActivities.memberId,
+          ),
+          eq(schema.memberGenerationActivities.generationId, generationId),
+        ),
+      )
+      .where(eq(schema.carrotShakeEvents.roundId, roundId))
+      .groupBy(schema.memberGenerationActivities.platform);
+  }
+}

--- a/src/danggn/danggns.service.ts
+++ b/src/danggn/danggns.service.ts
@@ -1,0 +1,209 @@
+import { Injectable } from '@nestjs/common';
+import { DanggnsException } from './danggns.exception';
+import { DanggnsRepository } from './danggns.repository';
+import { DanggnsCacheRepository } from './danggns-cache.repository';
+import { RankingRepository } from './ranking.repository';
+
+export type DanggnsRoundResponseDto = {
+  serverTime: string;
+  meta: {
+    roundNo: number;
+    startedAt: string;
+    endedAt: string;
+    myRank: number | null;
+    myScore: number | null;
+    myTeamRank: number | null;
+    myTeamScore: number | null;
+  };
+  rankings: {
+    crews: { memberId: number; name: string; score: number }[];
+    platforms: { platform: string; score: number }[];
+  };
+};
+
+const MOCK_USER_ID = 42;
+const MOCK_PLATFORM = 'NODE';
+
+@Injectable()
+export class DanggnsService {
+  constructor(
+    private readonly danggnsRepository: DanggnsRepository,
+    private readonly rankingRepository: RankingRepository,
+    private readonly danggnsCacheRepository: DanggnsCacheRepository,
+  ) {}
+
+  /**
+   * 라운드 랭킹 데이터를 조회합니다.
+   *
+   * - 종료된 라운드: 라운드 종료 시점에 확정된 스냅샷(carrot_round_rankings) 기준으로 조회합니다.
+   * - 진행 중인 라운드: Redis ZSet 기준으로 조회하며, ZSet이 없는 경우 DB 로그로 복구합니다.
+   *   ZSet 복구 여부는 키 자체의 존재로 판단합니다(특정 유저의 멤버십 여부가 아닌 라운드 단위).
+   *   미참여 유저의 경우 ZSet이 존재해도 zRevRank가 null을 반환하므로 myRank: null로 정상 처리됩니다.
+   */
+  async getRoundData(roundId: number): Promise<DanggnsRoundResponseDto> {
+    const round = await this.findRoundByIdOrThrow(roundId);
+
+    if (new Date() > round.endedAt) {
+      return this.getRoundDataFromSnapshot(round);
+    }
+
+    const memberKey = this.getMemberRoundKey(roundId);
+    const crewKey = this.getCrewRoundKey(roundId);
+
+    const [memberKeyExists, isRestored] = await Promise.all([
+      this.rankingRepository.exists(memberKey),
+      this.danggnsCacheRepository.isRankingRestored(roundId),
+    ]);
+    if (!memberKeyExists && !isRestored) {
+      await this.restoreRankingFromDb(roundId, round.generationId);
+    }
+
+    const [
+      myRankRaw,
+      myScoreRaw,
+      myTeamRankRaw,
+      myTeamScoreRaw,
+      crewEntries,
+      platformEntries,
+    ] = await Promise.all([
+      this.rankingRepository.zRevRank(memberKey, String(MOCK_USER_ID)),
+      this.rankingRepository.zScore(memberKey, String(MOCK_USER_ID)),
+      this.rankingRepository.zRevRank(crewKey, MOCK_PLATFORM),
+      this.rankingRepository.zScore(crewKey, MOCK_PLATFORM),
+      this.rankingRepository.zRevRangeWithScores(memberKey, 0, -1),
+      this.rankingRepository.zRevRangeWithScores(crewKey, 0, -1),
+    ]);
+
+    const memberIds = crewEntries.map((e) => Number(e.member));
+    const members = await this.danggnsRepository.findMembersByIds(memberIds);
+    const memberNameMap = new Map(members.map((m) => [m.id, m.name ?? '']));
+
+    return {
+      serverTime: new Date().toISOString(),
+      meta: {
+        roundNo: round.roundNo,
+        startedAt: round.startedAt.toISOString(),
+        endedAt: round.endedAt.toISOString(),
+        myRank: myRankRaw !== null ? myRankRaw + 1 : null,
+        myScore: myScoreRaw !== null ? Number(myScoreRaw) : null,
+        myTeamRank: myTeamRankRaw !== null ? myTeamRankRaw + 1 : null,
+        myTeamScore: myTeamScoreRaw !== null ? Number(myTeamScoreRaw) : null,
+      },
+      rankings: {
+        crews: crewEntries.map((e) => ({
+          memberId: Number(e.member),
+          name: memberNameMap.get(Number(e.member)) ?? '',
+          score: e.score,
+        })),
+        platforms: platformEntries.map((e) => ({
+          platform: e.member,
+          score: e.score,
+        })),
+      },
+    };
+  }
+
+  private async getRoundDataFromSnapshot(
+    round: Awaited<ReturnType<DanggnsRepository['findRoundById']>> & object,
+  ): Promise<DanggnsRoundResponseDto> {
+    const [rankingEntries, platformScores] = await Promise.all([
+      this.danggnsRepository.findRoundRankings(round.id),
+      this.danggnsRepository.aggregatePlatformScoresBySnapshot(
+        round.id,
+        round.generationId,
+      ),
+    ]);
+
+    const memberIds = rankingEntries.map((r) => r.memberId);
+    const members = await this.danggnsRepository.findMembersByIds(memberIds);
+    const memberNameMap = new Map(members.map((m) => [m.id, m.name ?? '']));
+
+    const myRanking = rankingEntries.find((r) => r.memberId === MOCK_USER_ID);
+    const myPlatformIdx = platformScores.findIndex(
+      (p) => p.platform === MOCK_PLATFORM,
+    );
+
+    return {
+      serverTime: new Date().toISOString(),
+      meta: {
+        roundNo: round.roundNo,
+        startedAt: round.startedAt.toISOString(),
+        endedAt: round.endedAt.toISOString(),
+        myRank: myRanking?.finalRank ?? null,
+        myScore: myRanking?.finalScore ?? null,
+        myTeamRank: myPlatformIdx !== -1 ? myPlatformIdx + 1 : null,
+        myTeamScore:
+          myPlatformIdx !== -1
+            ? platformScores[myPlatformIdx].totalScore
+            : null,
+      },
+      rankings: {
+        crews: rankingEntries.map((r) => ({
+          memberId: r.memberId,
+          name: memberNameMap.get(r.memberId) ?? '',
+          score: r.finalScore,
+        })),
+        platforms: platformScores.map((p) => ({
+          platform: p.platform,
+          score: p.totalScore,
+        })),
+      },
+    };
+  }
+
+  /**
+   * carrot_shake_events 로그를 집계해 Redis ZSet을 재구성합니다.
+   *
+   * DB 결과가 비어 있어도(라운드 시작 직후 등) setRankingRestored를 항상 호출해
+   * 30s TTL 마커를 설정함으로써 빈 라운드에 대한 반복적인 DB 조회를 방지합니다.
+   */
+  private async restoreRankingFromDb(
+    roundId: number,
+    generationId: number,
+  ): Promise<void> {
+    const [memberScores, platformScores] = await Promise.all([
+      this.danggnsRepository.aggregateShakeScoresByMember(roundId),
+      this.danggnsRepository.aggregateShakeScoresByPlatform(
+        roundId,
+        generationId,
+      ),
+    ]);
+
+    const memberKey = this.getMemberRoundKey(roundId);
+    const crewKey = this.getCrewRoundKey(roundId);
+
+    await Promise.all([
+      this.rankingRepository.zAddBulk(
+        memberKey,
+        memberScores.map((s) => ({
+          member: String(s.memberId),
+          score: s.totalScore,
+        })),
+      ),
+      this.rankingRepository.zAddBulk(
+        crewKey,
+        platformScores.map((s) => ({
+          member: s.platform,
+          score: s.totalScore,
+        })),
+      ),
+      this.danggnsCacheRepository.setRankingRestored(roundId),
+    ]);
+  }
+
+  private getMemberRoundKey(roundId: number) {
+    return `danggns:round:${roundId}:members`;
+  }
+
+  private getCrewRoundKey(roundId: number) {
+    return `danggns:round:${roundId}:crew`;
+  }
+
+  private async findRoundByIdOrThrow(roundId: number) {
+    const round = await this.danggnsRepository.findRoundById(roundId);
+    if (!round) {
+      throw DanggnsException.roundNotFound();
+    }
+    return round;
+  }
+}

--- a/src/danggn/ranking.repository.ts
+++ b/src/danggn/ranking.repository.ts
@@ -11,14 +11,6 @@ export type RedisSortedSetEntry = {
 export class RankingRepository {
   constructor(@Inject(REDIS_CLIENT) private readonly redisClient: Redis) {}
 
-  zAdd(key: string, score: number, member: string): Promise<number> {
-    return this.redisClient.zadd(key, score, member);
-  }
-
-  zIncrBy(key: string, increment: number, member: string): Promise<string> {
-    return this.redisClient.zincrby(key, increment, member);
-  }
-
   zScore(key: string, member: string): Promise<string | null> {
     return this.redisClient.zscore(key, member);
   }
@@ -35,6 +27,22 @@ export class RankingRepository {
     return this.redisClient
       .zrevrange(key, start, stop, 'WITHSCORES')
       .then((result) => this.toSortedSetEntries(result));
+  }
+
+  async exists(key: string): Promise<boolean> {
+    return (await this.redisClient.exists(key)) === 1;
+  }
+
+  async zAddBulk(
+    key: string,
+    entries: { score: number; member: string }[],
+  ): Promise<void> {
+    if (entries.length === 0) return;
+    const pipeline = this.redisClient.pipeline();
+    for (const { score, member } of entries) {
+      pipeline.zadd(key, score, member);
+    }
+    await pipeline.exec();
   }
 
   private toSortedSetEntries(flattened: string[]): RedisSortedSetEntry[] {

--- a/src/db/seed.danggn-shakes.ts
+++ b/src/db/seed.danggn-shakes.ts
@@ -1,0 +1,186 @@
+import 'dotenv/config';
+
+import { sql } from 'drizzle-orm';
+
+import { createDb, createPool } from './client';
+import * as schema from '../schema';
+
+// ── 조절 상수 ────────────────────────────────────────────────────
+const SHAKE_LOG_COUNT = 500; // 생성할 당근 흔들기 로그 수
+const MEMBER_COUNT = 20; // 생성할 멤버 수 (최대 80)
+// ────────────────────────────────────────────────────────────────
+
+const PLATFORMS = [
+  'NODE',
+  'SPRING',
+  'WEB',
+  'iOS',
+  'ANDROID',
+  'DESIGN',
+] as const;
+
+function randomInt(min: number, max: number) {
+  return Math.floor(Math.random() * (max - min + 1)) + min;
+}
+
+async function run() {
+  const databaseUrl = process.env.DATABASE_URL;
+  if (!databaseUrl) throw new Error('DATABASE_URL is required.');
+
+  const pool = createPool(databaseUrl);
+  const db = createDb(pool);
+
+  try {
+    // 1. generation 번호 채번
+    const [{ maxNumber }] = await db
+      .select({
+        maxNumber: sql<number>`coalesce(max(${schema.generations.number}), 0)`,
+      })
+      .from(schema.generations);
+
+    const [generation] = await db
+      .insert(schema.generations)
+      .values({
+        number: maxNumber + 1,
+        startedAt: new Date('2025-01-01'),
+        endedAt: new Date('2025-12-31'),
+        status: 'ACTIVE',
+      })
+      .returning();
+
+    // 2. members 생성
+    const tag = Date.now();
+    const memberRows = Array.from({ length: MEMBER_COUNT }, (_, i) => ({
+      oauthProvider: 'NAVER' as const,
+      oauthProviderUserId: `seed_${tag}_${i}`,
+      name: `시드멤버${i + 1}`,
+      signupCompleted: true,
+    }));
+
+    const members = await db
+      .insert(schema.members)
+      .values(memberRows)
+      .returning({ id: schema.members.id });
+
+    // 3. 플랫폼별로 멤버를 순환 배분 (NODE→SPRING→WEB→iOS→ANDROID→DESIGN→...)
+    const activityRows = members.map((m, i) => ({
+      memberId: m.id,
+      generationId: generation.id,
+      platform: PLATFORMS[i % PLATFORMS.length],
+      role: 'MEMBER' as const,
+      status: 'ACTIVE' as const,
+      joinedAt: new Date('2025-01-01'),
+    }));
+
+    await db.insert(schema.memberGenerationActivities).values(activityRows);
+
+    // 4. 현재 시각 기준 활성 라운드 생성 (1시간 전 ~ 1시간 후)
+    const now = new Date();
+    const [round] = await db
+      .insert(schema.carrotRounds)
+      .values({
+        generationId: generation.id,
+        roundNo: 1,
+        startedAt: new Date(now.getTime() - 60 * 60 * 1000),
+        endedAt: new Date(now.getTime() + 60 * 60 * 1000),
+      })
+      .returning();
+
+    // 5. shake 이벤트 생성 — 멤버에게 랜덤 분배
+    //    10% 확률로 피버 적용 점수(1000~10000), 나머지는 일반 점수(1~300)
+    //    members[0]은 MOCK_USER_ID 테스트용이므로 별도로 10건 보장
+    const memberIds = members.map((m) => m.id);
+    const mockMemberId = members[0].id;
+
+    function randomScoreDelta() {
+      return Math.random() < 0.1 ? randomInt(1000, 10000) : randomInt(1, 300);
+    }
+
+    const shakeRows = [
+      ...Array.from({ length: 10 }, () => ({
+        roundId: round.id,
+        memberId: mockMemberId,
+        scoreDelta: randomScoreDelta(),
+      })),
+      ...Array.from({ length: SHAKE_LOG_COUNT - 10 }, () => ({
+        roundId: round.id,
+        memberId: memberIds[randomInt(0, memberIds.length - 1)],
+        scoreDelta: randomScoreDelta(),
+      })),
+    ];
+
+    await db.insert(schema.carrotShakeEvents).values(shakeRows);
+
+    // 6. 종료된 라운드 생성 (2시간 전 ~ 1시간 전)
+    const [endedRound] = await db
+      .insert(schema.carrotRounds)
+      .values({
+        generationId: generation.id,
+        roundNo: 2,
+        startedAt: new Date(now.getTime() - 2 * 60 * 60 * 1000),
+        endedAt: new Date(now.getTime() - 60 * 60 * 1000),
+      })
+      .returning();
+
+    const endedShakeRows = [
+      ...Array.from({ length: 10 }, () => ({
+        roundId: endedRound.id,
+        memberId: mockMemberId,
+        scoreDelta: randomScoreDelta(),
+      })),
+      ...Array.from({ length: SHAKE_LOG_COUNT - 10 }, () => ({
+        roundId: endedRound.id,
+        memberId: memberIds[randomInt(0, memberIds.length - 1)],
+        scoreDelta: randomScoreDelta(),
+      })),
+    ];
+
+    await db.insert(schema.carrotShakeEvents).values(endedShakeRows);
+
+    // 7. 종료 라운드 랭킹 스냅샷 — 셰이크 이벤트에서 인메모리 집계 후 삽입
+    const memberScoreMap = new Map<number, number>();
+    for (const row of endedShakeRows) {
+      memberScoreMap.set(
+        row.memberId,
+        (memberScoreMap.get(row.memberId) ?? 0) + row.scoreDelta,
+      );
+    }
+
+    const rankingRows = [...memberScoreMap.entries()]
+      .sort((a, b) => b[1] - a[1])
+      .map(([memberId, totalScore], idx) => ({
+        roundId: endedRound.id,
+        memberId,
+        finalRank: idx + 1,
+        finalScore: totalScore,
+      }));
+
+    await db.insert(schema.carrotRoundRankings).values(rankingRows);
+
+    console.log('시딩 완료');
+    console.log(
+      `  generation id : ${generation.id} (번호: ${generation.number})`,
+    );
+    console.log(
+      `  members       : ${MEMBER_COUNT}명 (플랫폼당 ${Math.ceil(MEMBER_COUNT / PLATFORMS.length)}명 내외)`,
+    );
+    console.log('');
+    console.log(
+      `  [활성 라운드]  round id: ${round.id}  → GET /danggns/rounds/${round.id}`,
+    );
+    console.log(
+      `  [종료 라운드]  round id: ${endedRound.id}  → GET /danggns/rounds/${endedRound.id}`,
+    );
+    console.log('');
+    console.log(
+      `  myRank 확인용 MOCK_USER_ID → ${mockMemberId} (danggns.service.ts)`,
+    );
+  } finally {
+    await pool.end();
+  }
+}
+
+run().catch((error) => {
+  console.error(error);
+  process.exit(1);
+});


### PR DESCRIPTION
## #️⃣ 연관된 이슈

close #42 

## 📝 작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요

- 당근 흔들기 랭킹 회차별 상세 내용(메타데이터 및 랭킹 정보) 조회 기능을 구현하였습니다.
- 종료된 회차에 대해서는 스냅샷 기준으로 db 조회를 수행하고, 진행중인 회차에 대해서는 레디스를 조회합니다.
- 스케줄러를 돌려 회차 종료 시 스냅샷을 남긴다고 생각하였습니다. 이 때 레디스에 문제가 생길 가능성이 있기 때문에 당근 흔들기 시 저장된 로그를 기반으로 zset 내역을 복구할 수 있도록 하였습니다.
- 테스트 목적으로 종료된 랭킹 회차 및 진행중인 랭킹 회차에 대한 로그를 시딩하는 코드도 작성하였습니다.

## ✅ 테스트 / 검증 내용

> 작업 후 확인한 내용을 작성해주세요
>
lint 통과, build 통과, 로컬 API 동작 확인

## 📸 스크린샷 (선택)
<img width="880" height="723" alt="image" src="https://github.com/user-attachments/assets/81d5964e-1e8e-48ee-be7c-14f0205f55a8" />
<img width="719" height="177" alt="image" src="https://github.com/user-attachments/assets/7d864714-9be5-4b61-98fc-a005e1fd3766" />
※ 괄호 안의 (91)은 DB 복구가 포함된 최초 요청 시간으로 평균 계산에서 제외되었습니다.

캐싱 성능 테스트해보고 싶어서 로그 500개, 멤버 20명 기준으로 스냅샷/캐시 및 db 복구 시간 측정해보았습니다.
live(진행중인 랭킹)가 db 복구 제외하고는 snapshot(종료된 랭킹)에 비해 평균적으로 1.7배 정도 빠릅니다.

단적으로 조회만 보았을 때는 엄청난 차이라고 보기에는 힘들지만, 당근 흔들기에서 값을 계산해서 더하는 작업이나 db에 직접 결과를 update하는 과정이 덜하기 때문에 충분히 레디스를 도입할만 하지 않나! 싶어요

## 💬 리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?

## 📚 참고할 만한 자료(선택)
