### PR TITLE
feat(seminar): 이번 주 / 상세 세미나 조회 API 구현

### DIFF
--- a/src/seminar/dto/seminar-detail-response.dto.ts
+++ b/src/seminar/dto/seminar-detail-response.dto.ts
@@ -1,0 +1,40 @@
+import { z } from 'zod';
+
+const programItemSchema = z.object({
+  order: z.number(),
+  title: z.string(),
+  description: z.string().nullable(),
+  startsAt: z.string().nullable(),
+});
+
+const programSectionSchema = z.object({
+  sectionNo: z.number(),
+  title: z.string(),
+  startsAt: z.string().nullable(),
+  endsAt: z.string().nullable(),
+  items: z.array(programItemSchema),
+});
+
+const locationSchema = z.object({
+  name: z.string().nullable(),
+  address: z.string().nullable(),
+  latitude: z.number().nullable(),
+  longitude: z.number().nullable(),
+  mapImageUrl: z.string().nullable(),
+});
+
+export const seminarDetailResponseSchema = z.object({
+  seminarId: z.number(),
+  title: z.string(),
+  date: z.string(),
+  startsAt: z.string().nullable(),
+  endsAt: z.string().nullable(),
+  location: locationSchema,
+  notice: z.string().nullable(),
+  programSections: z.array(programSectionSchema),
+  attendanceAvailable: z.boolean(),
+});
+
+export type SeminarDetailResponseDto = z.infer<
+  typeof seminarDetailResponseSchema
+>;

--- a/src/seminar/dto/this-week-response.dto.ts
+++ b/src/seminar/dto/this-week-response.dto.ts
@@ -1,0 +1,52 @@
+import { z } from 'zod';
+
+const attendanceStatusSchema = z.enum([
+  'ATTENDED',
+  'LATE',
+  'ABSENT',
+  'PENDING',
+]);
+
+const attendancePhaseSchema = z.enum(['BEFORE', 'IN_PROGRESS', 'COMPLETED']);
+
+const attendanceRecordSchema = z.object({
+  checkpointId: z.number(),
+  label: z.string(),
+  status: attendanceStatusSchema,
+  checkedAt: z.string().nullable(),
+});
+
+const attendanceSchema = z.object({
+  phase: attendancePhaseSchema,
+  viewerName: z.string(),
+  records: z.array(attendanceRecordSchema),
+});
+
+const badgeSchema = z.object({
+  type: z.literal('SEMINAR'),
+  label: z.string(),
+});
+
+const thisWeekSeminarSchema = z.object({
+  seminarId: z.number(),
+  badge: badgeSchema,
+  title: z.string(),
+  startsAt: z.string().nullable(),
+  endsAt: z.string().nullable(),
+  locationName: z.string().nullable(),
+  notice: z.string().nullable(),
+  attendance: attendanceSchema,
+});
+
+export const thisWeekResponseSchema = z.object({
+  serverTime: z.string(),
+  generation: z.object({ id: z.number(), number: z.number() }),
+  daysUntilNextSeminar: z.number().nullable(),
+  thisWeekSeminar: thisWeekSeminarSchema.nullable(),
+});
+
+export type ThisWeekResponseDto = z.infer<typeof thisWeekResponseSchema>;
+export type ThisWeekSeminar = z.infer<typeof thisWeekSeminarSchema>;
+export type Attendance = z.infer<typeof attendanceSchema>;
+export type AttendanceStatus = z.infer<typeof attendanceStatusSchema>;
+export type AttendancePhase = z.infer<typeof attendancePhaseSchema>;

--- a/src/seminar/seminar.controller.ts
+++ b/src/seminar/seminar.controller.ts
@@ -11,7 +11,7 @@ export class SeminarController {
   // 'weekly' 라우트는 ':seminarId'보다 먼저 정의되어야 매칭 충돌이 없음
   @Get('weekly')
   getThisWeek() {
-    return this.seminarService.getThisWeek();
+    return this.seminarService.getThisWeek(STUB_VIEWER_ID);
   }
 
   @Get()

--- a/src/seminar/seminar.exception.ts
+++ b/src/seminar/seminar.exception.ts
@@ -10,3 +10,13 @@ export class ActiveGenerationNotFoundException extends BaseException {
     );
   }
 }
+
+export class SeminarNotFoundException extends BaseException {
+  constructor(seminarId: number) {
+    super(
+      HttpStatus.NOT_FOUND,
+      'SEMINAR_NOT_FOUND',
+      `세미나(id=${seminarId})를 찾을 수 없습니다.`,
+    );
+  }
+}

--- a/src/seminar/seminar.repository.ts
+++ b/src/seminar/seminar.repository.ts
@@ -1,5 +1,5 @@
 import { Inject, Injectable } from '@nestjs/common';
-import { and, asc, eq } from 'drizzle-orm';
+import { and, asc, eq, getTableColumns, gte, lt } from 'drizzle-orm';
 import type { NodePgDatabase } from 'drizzle-orm/node-postgres';
 import { DRIZZLE_DB } from '../db/db.constants';
 import * as schema from '../schema';
@@ -10,6 +10,10 @@ export type ActiveGeneration = {
 };
 
 export type SeminarSchedule = typeof schema.seminarSchedules.$inferSelect;
+export type AttendanceCheckpoint =
+  typeof schema.attendanceCheckpoints.$inferSelect;
+export type SeminarAttendanceRecord =
+  typeof schema.seminarAttendanceRecords.$inferSelect;
 
 @Injectable()
 export class SeminarRepository {
@@ -17,6 +21,16 @@ export class SeminarRepository {
     @Inject(DRIZZLE_DB)
     private readonly db: NodePgDatabase<typeof schema>,
   ) {}
+
+  async findMemberName(memberId: number): Promise<string | null> {
+    const [row] = await this.db
+      .select({ name: schema.members.name })
+      .from(schema.members)
+      .where(eq(schema.members.id, memberId))
+      .limit(1);
+
+    return row?.name ?? null;
+  }
 
   async findActiveGeneration(
     memberId: number,
@@ -51,5 +65,86 @@ export class SeminarRepository {
       .from(schema.seminarSchedules)
       .where(eq(schema.seminarSchedules.generationId, generationId))
       .orderBy(asc(schema.seminarSchedules.startedAt)); // PostgreSQL ASC: NULLS LAST
+  }
+
+  /**
+   * 이번 주(KST 기준 UTC range) 안에 시작하는 첫 번째 세미나를 조회 (시간 오름차순).
+   * 운영 정책상 한 주에 정기 세미나는 1건이므로 단건 반환. 없으면 null.
+   * startedAt이 null인 schedule은 제외.
+   */
+  async findThisWeekSchedule(
+    generationId: number,
+    weekStart: Date,
+    weekEnd: Date,
+  ): Promise<SeminarSchedule | null> {
+    const [row] = await this.db
+      .select()
+      .from(schema.seminarSchedules)
+      .where(
+        and(
+          eq(schema.seminarSchedules.generationId, generationId),
+          gte(schema.seminarSchedules.startedAt, weekStart),
+          lt(schema.seminarSchedules.startedAt, weekEnd),
+        ),
+      )
+      .orderBy(asc(schema.seminarSchedules.startedAt))
+      .limit(1);
+
+    return row ?? null;
+  }
+
+  /**
+   * 현재 시각 이후 가장 가까운 세미나의 시작 시각을 조회 (이번 주 포함).
+   * D-day 계산용.
+   */
+  async findNextScheduleStartedAt(
+    generationId: number,
+    now: Date,
+  ): Promise<Date | null> {
+    const [row] = await this.db
+      .select({ startedAt: schema.seminarSchedules.startedAt })
+      .from(schema.seminarSchedules)
+      .where(
+        and(
+          eq(schema.seminarSchedules.generationId, generationId),
+          gte(schema.seminarSchedules.startedAt, now),
+        ),
+      )
+      .orderBy(asc(schema.seminarSchedules.startedAt))
+      .limit(1);
+
+    return row?.startedAt ?? null;
+  }
+
+  findCheckpointsBySchedule(
+    scheduleId: number,
+  ): Promise<AttendanceCheckpoint[]> {
+    return this.db
+      .select()
+      .from(schema.attendanceCheckpoints)
+      .where(eq(schema.attendanceCheckpoints.seminarScheduleId, scheduleId))
+      .orderBy(asc(schema.attendanceCheckpoints.roundNo));
+  }
+
+  findRecordsByMemberAndSchedule(
+    memberId: number,
+    scheduleId: number,
+  ): Promise<SeminarAttendanceRecord[]> {
+    return this.db
+      .select(getTableColumns(schema.seminarAttendanceRecords))
+      .from(schema.seminarAttendanceRecords)
+      .innerJoin(
+        schema.attendanceCheckpoints,
+        eq(
+          schema.seminarAttendanceRecords.attendanceCheckpointId,
+          schema.attendanceCheckpoints.id,
+        ),
+      )
+      .where(
+        and(
+          eq(schema.seminarAttendanceRecords.memberId, memberId),
+          eq(schema.attendanceCheckpoints.seminarScheduleId, scheduleId),
+        ),
+      );
   }
 }

--- a/src/seminar/seminar.repository.ts
+++ b/src/seminar/seminar.repository.ts
@@ -10,6 +10,8 @@ export type ActiveGeneration = {
 };
 
 export type SeminarSchedule = typeof schema.seminarSchedules.$inferSelect;
+export type SeminarSection = typeof schema.seminarSections.$inferSelect;
+export type SeminarItem = typeof schema.seminarItems.$inferSelect;
 export type AttendanceCheckpoint =
   typeof schema.attendanceCheckpoints.$inferSelect;
 export type SeminarAttendanceRecord =
@@ -114,6 +116,40 @@ export class SeminarRepository {
       .limit(1);
 
     return row?.startedAt ?? null;
+  }
+
+  async findScheduleById(id: number): Promise<SeminarSchedule | null> {
+    const [row] = await this.db
+      .select()
+      .from(schema.seminarSchedules)
+      .where(eq(schema.seminarSchedules.id, id))
+      .limit(1);
+
+    return row ?? null;
+  }
+
+  findSectionsBySchedule(scheduleId: number): Promise<SeminarSection[]> {
+    return this.db
+      .select()
+      .from(schema.seminarSections)
+      .where(eq(schema.seminarSections.seminarScheduleId, scheduleId))
+      .orderBy(asc(schema.seminarSections.sortOrder));
+  }
+
+  /**
+   * 한 schedule에 속한 모든 program items를 sortOrder 순으로 조회.
+   * items 테이블엔 scheduleId가 없어 sections를 거쳐 join.
+   */
+  findItemsBySchedule(scheduleId: number): Promise<SeminarItem[]> {
+    return this.db
+      .select(getTableColumns(schema.seminarItems))
+      .from(schema.seminarItems)
+      .innerJoin(
+        schema.seminarSections,
+        eq(schema.seminarItems.seminarSectionId, schema.seminarSections.id),
+      )
+      .where(eq(schema.seminarSections.seminarScheduleId, scheduleId))
+      .orderBy(asc(schema.seminarItems.sortOrder));
   }
 
   findCheckpointsBySchedule(

--- a/src/seminar/seminar.service.spec.ts
+++ b/src/seminar/seminar.service.spec.ts
@@ -1,5 +1,8 @@
 import { Test, TestingModule } from '@nestjs/testing';
-import { ActiveGenerationNotFoundException } from './seminar.exception';
+import {
+  ActiveGenerationNotFoundException,
+  SeminarNotFoundException,
+} from './seminar.exception';
 import { SeminarRepository } from './seminar.repository';
 import { SeminarService } from './seminar.service';
 
@@ -21,6 +24,9 @@ describe('SeminarService', () => {
             findNextScheduleStartedAt: jest.fn(),
             findCheckpointsBySchedule: jest.fn(),
             findRecordsByMemberAndSchedule: jest.fn(),
+            findScheduleById: jest.fn(),
+            findSectionsBySchedule: jest.fn(),
+            findItemsBySchedule: jest.fn(),
           },
         },
       ],
@@ -364,6 +370,206 @@ describe('SeminarService', () => {
       expect(result.thisWeekSeminar?.attendance.phase).toBe(expected);
     });
   });
+
+  describe('getDetail', () => {
+    beforeEach(() => {
+      // KST 2026-05-02(토) 12:00 = UTC 03:00 — checkpoint #2 (10~12 UTC)는 닫힘, #3 진행 중 가정용
+      jest.useFakeTimers().setSystemTime(new Date('2026-05-02T11:00:00.000Z'));
+      // 기본은 빈 sections / items / checkpoints
+      repository.findSectionsBySchedule.mockResolvedValue([]);
+      repository.findItemsBySchedule.mockResolvedValue([]);
+      repository.findCheckpointsBySchedule.mockResolvedValue([]);
+    });
+
+    afterEach(() => {
+      jest.useRealTimers();
+    });
+
+    it('schedule이 없으면 SeminarNotFoundException', async () => {
+      repository.findScheduleById.mockResolvedValue(null);
+
+      await expect(service.getDetail(999)).rejects.toBeInstanceOf(
+        SeminarNotFoundException,
+      );
+    });
+
+    it('schedule.startedAt이 null이면 SeminarNotFoundException (정보 미정 일정 차단)', async () => {
+      repository.findScheduleById.mockResolvedValue(
+        buildSchedule({ id: 10, startedAt: null }),
+      );
+
+      await expect(service.getDetail(10)).rejects.toBeInstanceOf(
+        SeminarNotFoundException,
+      );
+    });
+
+    it('schedule + sections + items를 매핑하여 응답을 구성한다', async () => {
+      repository.findScheduleById.mockResolvedValue(
+        buildSchedule({
+          id: 10,
+          title: '1차 정기 세미나',
+          startedAt: new Date('2026-05-02T03:00:00Z'),
+          endedAt: new Date('2026-05-02T07:00:00Z'),
+          venueName: '강남',
+          venueAddress: '서울시 강남구',
+          venueLat: '37.498095',
+          venueLng: '127.027610',
+          notice: '공지사항',
+        }),
+      );
+      repository.findSectionsBySchedule.mockResolvedValue([
+        buildSection({
+          id: 1,
+          seminarScheduleId: 10,
+          sortOrder: 1,
+          title: 'OT',
+          startedAt: new Date('2026-05-02T03:00:00Z'),
+          endedAt: new Date('2026-05-02T04:00:00Z'),
+        }),
+        buildSection({
+          id: 2,
+          seminarScheduleId: 10,
+          sortOrder: 2,
+          title: '세미나 발표',
+          startedAt: new Date('2026-05-02T04:00:00Z'),
+          endedAt: new Date('2026-05-02T07:00:00Z'),
+        }),
+      ]);
+      repository.findItemsBySchedule.mockResolvedValue([
+        buildItem({
+          id: 11,
+          seminarSectionId: 1,
+          sortOrder: 1,
+          title: '환영사',
+          description: null,
+          startedAt: new Date('2026-05-02T03:00:00Z'),
+        }),
+        buildItem({
+          id: 12,
+          seminarSectionId: 1,
+          sortOrder: 2,
+          title: '조 발표',
+          startedAt: new Date('2026-05-02T03:30:00Z'),
+        }),
+        buildItem({
+          id: 21,
+          seminarSectionId: 2,
+          sortOrder: 1,
+          title: 'Node 1번',
+          description: '발표 설명',
+          startedAt: new Date('2026-05-02T04:00:00Z'),
+        }),
+      ]);
+
+      const result = await service.getDetail(10);
+
+      expect(result).toEqual({
+        seminarId: 10,
+        title: '1차 정기 세미나',
+        date: '2026-05-02',
+        startsAt: '2026-05-02T03:00:00.000Z',
+        endsAt: '2026-05-02T07:00:00.000Z',
+        location: {
+          name: '강남',
+          address: '서울시 강남구',
+          latitude: 37.498095,
+          longitude: 127.02761,
+          mapImageUrl: null,
+        },
+        notice: '공지사항',
+        programSections: [
+          {
+            sectionNo: 1,
+            title: 'OT',
+            startsAt: '2026-05-02T03:00:00.000Z',
+            endsAt: '2026-05-02T04:00:00.000Z',
+            items: [
+              {
+                order: 1,
+                title: '환영사',
+                description: null,
+                startsAt: '2026-05-02T03:00:00.000Z',
+              },
+              {
+                order: 2,
+                title: '조 발표',
+                description: null,
+                startsAt: '2026-05-02T03:30:00.000Z',
+              },
+            ],
+          },
+          {
+            sectionNo: 2,
+            title: '세미나 발표',
+            startsAt: '2026-05-02T04:00:00.000Z',
+            endsAt: '2026-05-02T07:00:00.000Z',
+            items: [
+              {
+                order: 1,
+                title: 'Node 1번',
+                description: '발표 설명',
+                startsAt: '2026-05-02T04:00:00.000Z',
+              },
+            ],
+          },
+        ],
+        attendanceAvailable: false,
+      });
+    });
+
+    it('checkpoint 중 openedAt~closedAt 사이에 now가 있으면 attendanceAvailable=true', async () => {
+      repository.findScheduleById.mockResolvedValue(
+        buildSchedule({
+          id: 10,
+          startedAt: new Date('2026-05-02T03:00:00Z'),
+        }),
+      );
+      repository.findCheckpointsBySchedule.mockResolvedValue([
+        buildCheckpoint({
+          id: 101,
+          openedAt: new Date('2026-05-02T10:00:00Z'),
+          closedAt: new Date('2026-05-02T12:00:00Z'),
+        }),
+      ]);
+
+      const result = await service.getDetail(10);
+      expect(result.attendanceAvailable).toBe(true);
+    });
+
+    it('모든 checkpoint가 닫혀 있으면 attendanceAvailable=false', async () => {
+      repository.findScheduleById.mockResolvedValue(
+        buildSchedule({
+          id: 10,
+          startedAt: new Date('2026-05-02T03:00:00Z'),
+        }),
+      );
+      repository.findCheckpointsBySchedule.mockResolvedValue([
+        buildCheckpoint({
+          id: 101,
+          openedAt: new Date('2026-05-02T06:00:00Z'),
+          closedAt: new Date('2026-05-02T08:00:00Z'),
+        }),
+      ]);
+
+      const result = await service.getDetail(10);
+      expect(result.attendanceAvailable).toBe(false);
+    });
+
+    it('venueLat/Lng이 null이면 latitude/longitude도 null', async () => {
+      repository.findScheduleById.mockResolvedValue(
+        buildSchedule({
+          id: 10,
+          startedAt: new Date('2026-05-02T03:00:00Z'),
+          venueLat: null,
+          venueLng: null,
+        }),
+      );
+
+      const result = await service.getDetail(10);
+      expect(result.location.latitude).toBeNull();
+      expect(result.location.longitude).toBeNull();
+    });
+  });
 });
 
 function buildSchedule(
@@ -385,6 +591,46 @@ function baseSchedule() {
     venueLat: null as string | null,
     venueLng: null as string | null,
     notice: null as string | null,
+    createdAt: new Date(),
+    updatedAt: new Date(),
+  };
+}
+
+function buildSection(
+  overrides: Partial<ReturnType<typeof baseSection>>,
+): ReturnType<typeof baseSection> {
+  return { ...baseSection(), ...overrides };
+}
+
+function baseSection() {
+  return {
+    id: 1,
+    seminarScheduleId: 10,
+    title: 'Section',
+    description: null as string | null,
+    startedAt: null as Date | null,
+    endedAt: null as Date | null,
+    sortOrder: 1,
+    createdAt: new Date(),
+    updatedAt: new Date(),
+  };
+}
+
+function buildItem(
+  overrides: Partial<ReturnType<typeof baseItem>>,
+): ReturnType<typeof baseItem> {
+  return { ...baseItem(), ...overrides };
+}
+
+function baseItem() {
+  return {
+    id: 1,
+    seminarSectionId: 1,
+    title: 'Item',
+    description: null as string | null,
+    startedAt: null as Date | null,
+    endedAt: null as Date | null,
+    sortOrder: 1,
     createdAt: new Date(),
     updatedAt: new Date(),
   };

--- a/src/seminar/seminar.service.spec.ts
+++ b/src/seminar/seminar.service.spec.ts
@@ -15,7 +15,12 @@ describe('SeminarService', () => {
           provide: SeminarRepository,
           useValue: {
             findActiveGeneration: jest.fn(),
+            findMemberName: jest.fn(),
             findSchedulesByGeneration: jest.fn(),
+            findThisWeekSchedule: jest.fn(),
+            findNextScheduleStartedAt: jest.fn(),
+            findCheckpointsBySchedule: jest.fn(),
+            findRecordsByMemberAndSchedule: jest.fn(),
           },
         },
       ],
@@ -160,6 +165,205 @@ describe('SeminarService', () => {
       expect(ids).toEqual([2]);
     });
   });
+
+  describe('getThisWeek', () => {
+    beforeEach(() => {
+      // KST 2026-04-29(수) 12:00 = UTC 2026-04-29T03:00:00Z
+      // 이번 주 = KST 4/27(월) ~ 5/4(월) = UTC 4/26 15:00 ~ 5/3 15:00
+      jest.useFakeTimers().setSystemTime(new Date('2026-04-29T03:00:00.000Z'));
+    });
+
+    afterEach(() => {
+      jest.useRealTimers();
+    });
+
+    it('viewer 활동 기수가 없으면 ActiveGenerationNotFoundException을 던진다', async () => {
+      repository.findActiveGeneration.mockResolvedValue(null);
+      repository.findMemberName.mockResolvedValue('김매숑');
+
+      await expect(service.getThisWeek(99)).rejects.toBeInstanceOf(
+        ActiveGenerationNotFoundException,
+      );
+    });
+
+    it('이번 주 세미나가 없으면 thisWeekSeminar는 null', async () => {
+      repository.findActiveGeneration.mockResolvedValue({ id: 16, number: 16 });
+      repository.findMemberName.mockResolvedValue('김매숑');
+      repository.findThisWeekSchedule.mockResolvedValue(null);
+      repository.findNextScheduleStartedAt.mockResolvedValue(
+        new Date('2026-05-15T03:00:00Z'), // 16일 후
+      );
+      repository.findCheckpointsBySchedule.mockResolvedValue([]);
+      repository.findRecordsByMemberAndSchedule.mockResolvedValue([]);
+
+      const result = await service.getThisWeek(1);
+
+      expect(result.thisWeekSeminar).toBeNull();
+      expect(result.daysUntilNextSeminar).toBe(16);
+      expect(result.generation).toEqual({ id: 16, number: 16 });
+      expect(result.serverTime).toBe('2026-04-29T03:00:00.000Z');
+    });
+
+    it('checkpoints가 있으면 attendance.records를 채우고 viewerName을 포함 (record 없는 부분은 PENDING)', async () => {
+      repository.findActiveGeneration.mockResolvedValue({ id: 16, number: 16 });
+      repository.findMemberName.mockResolvedValue('김매숑');
+      repository.findThisWeekSchedule.mockResolvedValue(
+        buildSchedule({
+          id: 10,
+          startedAt: new Date('2026-05-02T03:00:00Z'),
+        }),
+      );
+      repository.findNextScheduleStartedAt.mockResolvedValue(
+        new Date('2026-05-02T03:00:00Z'),
+      );
+      repository.findCheckpointsBySchedule.mockResolvedValue([
+        buildCheckpoint({
+          id: 101,
+          seminarScheduleId: 10,
+          roundNo: 1,
+          title: '1부',
+        }),
+        buildCheckpoint({
+          id: 102,
+          seminarScheduleId: 10,
+          roundNo: 2,
+          title: '2부',
+        }),
+        buildCheckpoint({
+          id: 103,
+          seminarScheduleId: 10,
+          roundNo: 3,
+          title: '최종',
+        }),
+      ]);
+      repository.findRecordsByMemberAndSchedule.mockResolvedValue([
+        buildRecord({
+          attendanceCheckpointId: 101,
+          memberId: 1,
+          status: 'ATTENDED',
+          checkedAt: new Date('2026-05-02T03:30:00Z'),
+        }),
+      ]);
+
+      const result = await service.getThisWeek(1);
+      const seminar = result.thisWeekSeminar;
+
+      expect(seminar).not.toBeNull();
+      expect(seminar!.attendance.viewerName).toBe('김매숑');
+      expect(seminar!.attendance.records).toEqual([
+        {
+          checkpointId: 101,
+          label: '1부',
+          status: 'ATTENDED',
+          checkedAt: '2026-05-02T03:30:00.000Z',
+        },
+        {
+          checkpointId: 102,
+          label: '2부',
+          status: 'PENDING',
+          checkedAt: null,
+        },
+        {
+          checkpointId: 103,
+          label: '최종',
+          status: 'PENDING',
+          checkedAt: null,
+        },
+      ]);
+      expect(seminar!.badge).toEqual({ type: 'SEMINAR', label: 'Semina' });
+    });
+
+    it('checkpoints가 없으면 attendance는 phase=BEFORE, records=[] 빈 객체', async () => {
+      repository.findActiveGeneration.mockResolvedValue({ id: 16, number: 16 });
+      repository.findMemberName.mockResolvedValue('김매숑');
+      repository.findThisWeekSchedule.mockResolvedValue(
+        buildSchedule({
+          id: 20,
+          startedAt: new Date('2026-05-02T03:00:00Z'),
+        }),
+      );
+      repository.findNextScheduleStartedAt.mockResolvedValue(
+        new Date('2026-05-02T03:00:00Z'),
+      );
+      repository.findCheckpointsBySchedule.mockResolvedValue([]);
+      repository.findRecordsByMemberAndSchedule.mockResolvedValue([]);
+
+      const result = await service.getThisWeek(1);
+      expect(result.thisWeekSeminar?.attendance).toEqual({
+        phase: 'BEFORE',
+        viewerName: '김매숑',
+        records: [],
+      });
+    });
+
+    it('가까운 미래 세미나가 없으면 daysUntilNextSeminar는 null', async () => {
+      repository.findActiveGeneration.mockResolvedValue({ id: 16, number: 16 });
+      repository.findMemberName.mockResolvedValue('김매숑');
+      repository.findThisWeekSchedule.mockResolvedValue(null);
+      repository.findNextScheduleStartedAt.mockResolvedValue(null);
+      repository.findCheckpointsBySchedule.mockResolvedValue([]);
+      repository.findRecordsByMemberAndSchedule.mockResolvedValue([]);
+
+      const result = await service.getThisWeek(1);
+      expect(result.daysUntilNextSeminar).toBeNull();
+    });
+  });
+
+  describe('attendance phase 계산 (private 메서드 동작 검증, getThisWeek 통한 간접 검증)', () => {
+    beforeEach(() => {
+      repository.findActiveGeneration.mockResolvedValue({ id: 16, number: 16 });
+      repository.findMemberName.mockResolvedValue('김매숑');
+      repository.findThisWeekSchedule.mockResolvedValue(
+        buildSchedule({
+          id: 10,
+          startedAt: new Date('2026-05-02T03:00:00Z'),
+        }),
+      );
+      repository.findNextScheduleStartedAt.mockResolvedValue(
+        new Date('2026-05-02T03:00:00Z'),
+      );
+      repository.findRecordsByMemberAndSchedule.mockResolvedValue([]);
+    });
+
+    afterEach(() => {
+      jest.useRealTimers();
+    });
+
+    const checkpoints = [
+      buildCheckpoint({
+        id: 101,
+        roundNo: 1,
+        openedAt: new Date('2026-05-02T06:00:00Z'),
+        closedAt: new Date('2026-05-02T08:00:00Z'),
+      }),
+      buildCheckpoint({
+        id: 102,
+        roundNo: 2,
+        openedAt: new Date('2026-05-02T10:00:00Z'),
+        closedAt: new Date('2026-05-02T12:00:00Z'),
+      }),
+      buildCheckpoint({
+        id: 103,
+        roundNo: 3,
+        openedAt: new Date('2026-05-02T14:00:00Z'),
+        closedAt: new Date('2026-05-02T16:00:00Z'),
+      }),
+    ];
+
+    it.each([
+      ['첫 openedAt 전', '2026-05-02T05:00:00.000Z', 'BEFORE'],
+      ['첫 openedAt 정각', '2026-05-02T06:00:00.000Z', 'IN_PROGRESS'],
+      ['체크포인트 사이 휴식', '2026-05-02T09:00:00.000Z', 'IN_PROGRESS'],
+      ['마지막 closedAt 정각', '2026-05-02T16:00:00.000Z', 'IN_PROGRESS'],
+      ['마지막 closedAt 직후', '2026-05-02T16:00:00.001Z', 'COMPLETED'],
+    ])('%s → %s', async (_desc, nowIso, expected) => {
+      jest.useFakeTimers().setSystemTime(new Date(nowIso));
+      repository.findCheckpointsBySchedule.mockResolvedValue(checkpoints);
+
+      const result = await service.getThisWeek(1);
+      expect(result.thisWeekSeminar?.attendance.phase).toBe(expected);
+    });
+  });
 });
 
 function buildSchedule(
@@ -181,6 +385,46 @@ function baseSchedule() {
     venueLat: null as string | null,
     venueLng: null as string | null,
     notice: null as string | null,
+    createdAt: new Date(),
+    updatedAt: new Date(),
+  };
+}
+
+function buildCheckpoint(
+  overrides: Partial<ReturnType<typeof baseCheckpoint>>,
+): ReturnType<typeof baseCheckpoint> {
+  return { ...baseCheckpoint(), ...overrides };
+}
+
+function baseCheckpoint() {
+  return {
+    id: 101,
+    seminarScheduleId: 10,
+    roundNo: 1,
+    title: '1부',
+    openedAt: new Date('2026-05-02T03:00:00Z'),
+    lateAt: new Date('2026-05-02T04:00:00Z'),
+    closedAt: new Date('2026-05-02T05:00:00Z'),
+    createdAt: new Date(),
+    updatedAt: new Date(),
+  };
+}
+
+function buildRecord(
+  overrides: Partial<ReturnType<typeof baseRecord>>,
+): ReturnType<typeof baseRecord> {
+  return { ...baseRecord(), ...overrides };
+}
+
+function baseRecord() {
+  return {
+    id: 1,
+    attendanceCheckpointId: 101,
+    memberId: 1,
+    scoreDelta: 0,
+    status: 'ATTENDED' as 'ATTENDED' | 'LATE' | 'ABSENT',
+    checkedAt: null as Date | null,
+    checkMethod: null as 'QR' | 'MANUAL' | null,
     createdAt: new Date(),
     updatedAt: new Date(),
   };

--- a/src/seminar/seminar.service.ts
+++ b/src/seminar/seminar.service.ts
@@ -1,5 +1,5 @@
 import { Injectable } from '@nestjs/common';
-import { format } from 'date-fns';
+import { differenceInCalendarDays, format } from 'date-fns';
 import { toZonedTime } from 'date-fns-tz';
 import {
   DEFAULT_TIMEZONE,
@@ -10,8 +10,20 @@ import type {
   ScheduleItem,
   SchedulesResponseDto,
 } from './dto/schedules-response.dto';
+import type {
+  Attendance,
+  AttendancePhase,
+  AttendanceStatus,
+  ThisWeekResponseDto,
+  ThisWeekSeminar,
+} from './dto/this-week-response.dto';
 import { ActiveGenerationNotFoundException } from './seminar.exception';
-import { SeminarRepository, type SeminarSchedule } from './seminar.repository';
+import {
+  SeminarRepository,
+  type AttendanceCheckpoint,
+  type SeminarAttendanceRecord,
+  type SeminarSchedule,
+} from './seminar.repository';
 
 type ScheduleWithDate = SeminarSchedule & { startedAt: Date };
 
@@ -53,6 +65,31 @@ export class SeminarService {
     );
   }
 
+  /**
+   * 출석 시간별 체크포인트 목록과 현재 시각으로 phase를 계산.
+   * - now < 첫 체크포인트 openedAt → BEFORE
+   * - 첫 openedAt <= now <= 마지막 closedAt → IN_PROGRESS
+   * - 마지막 closedAt < now → COMPLETED
+   */
+  private calculateAttendancePhase(
+    checkpoints: AttendanceCheckpoint[],
+    now: Date,
+  ): AttendancePhase {
+    if (checkpoints.length === 0) return 'BEFORE';
+
+    const firstOpenedAt = Math.min(
+      ...checkpoints.map((c) => c.openedAt.getTime()),
+    );
+    const lastClosedAt = Math.max(
+      ...checkpoints.map((c) => c.closedAt.getTime()),
+    );
+    const nowMs = now.getTime();
+
+    if (nowMs < firstOpenedAt) return 'BEFORE';
+    if (nowMs <= lastClosedAt) return 'IN_PROGRESS';
+    return 'COMPLETED';
+  }
+
   private toScheduleItem(
     schedule: ScheduleWithDate,
     weekStart: Date,
@@ -73,6 +110,40 @@ export class SeminarService {
       endsAt: schedule.endedAt?.toISOString() ?? null,
       locationName: schedule.venueName,
       isHighlighted: isThisWeek,
+    };
+  }
+
+  private toThisWeekSeminar(
+    schedule: SeminarSchedule,
+    checkpoints: AttendanceCheckpoint[],
+    recordsByCheckpoint: Map<number, SeminarAttendanceRecord>,
+    viewerName: string,
+    now: Date,
+  ): ThisWeekSeminar {
+    const attendance: Attendance = {
+      phase: this.calculateAttendancePhase(checkpoints, now),
+      viewerName,
+      records: checkpoints.map((cp) => {
+        const record = recordsByCheckpoint.get(cp.id);
+        const status: AttendanceStatus = record?.status ?? 'PENDING';
+        return {
+          checkpointId: cp.id,
+          label: cp.title,
+          status,
+          checkedAt: record?.checkedAt?.toISOString() ?? null,
+        };
+      }),
+    };
+
+    return {
+      seminarId: schedule.id,
+      badge: { type: 'SEMINAR', label: 'Semina' },
+      title: schedule.title,
+      startsAt: schedule.startedAt?.toISOString() ?? null,
+      endsAt: schedule.endedAt?.toISOString() ?? null,
+      locationName: schedule.venueName,
+      notice: schedule.notice,
+      attendance,
     };
   }
 
@@ -100,9 +171,59 @@ export class SeminarService {
     };
   }
 
-  // TODO(seminar): 후속 커밋에서 구현
-  async getThisWeek() {
-    return null;
+  async getThisWeek(viewerId: number): Promise<ThisWeekResponseDto> {
+    const [generation, viewerName] = await Promise.all([
+      this.seminarRepository.findActiveGeneration(viewerId),
+      this.seminarRepository.findMemberName(viewerId),
+    ]);
+    if (!generation) {
+      throw new ActiveGenerationNotFoundException();
+    }
+
+    const now = new Date();
+    const { start: weekStart, end: weekEnd } = getThisWeekRange(now);
+
+    const [thisWeekSchedule, nextStartedAt] = await Promise.all([
+      this.seminarRepository.findThisWeekSchedule(
+        generation.id,
+        weekStart,
+        weekEnd,
+      ),
+      this.seminarRepository.findNextScheduleStartedAt(generation.id, now),
+    ]);
+
+    const [checkpoints, records] = thisWeekSchedule
+      ? await Promise.all([
+          this.seminarRepository.findCheckpointsBySchedule(thisWeekSchedule.id),
+          this.seminarRepository.findRecordsByMemberAndSchedule(
+            viewerId,
+            thisWeekSchedule.id,
+          ),
+        ])
+      : [[], []];
+    const recordsByCheckpoint = new Map(
+      records.map((r) => [r.attendanceCheckpointId, r]),
+    );
+
+    return {
+      serverTime: now.toISOString(),
+      generation,
+      daysUntilNextSeminar: nextStartedAt
+        ? differenceInCalendarDays(
+            toZonedTime(nextStartedAt, DEFAULT_TIMEZONE),
+            toZonedTime(now, DEFAULT_TIMEZONE),
+          )
+        : null,
+      thisWeekSeminar: thisWeekSchedule
+        ? this.toThisWeekSeminar(
+            thisWeekSchedule,
+            checkpoints,
+            recordsByCheckpoint,
+            viewerName ?? '',
+            now,
+          )
+        : null,
+    };
   }
 
   // TODO(seminar): 후속 커밋에서 구현

--- a/src/seminar/seminar.service.ts
+++ b/src/seminar/seminar.service.ts
@@ -10,6 +10,7 @@ import type {
   ScheduleItem,
   SchedulesResponseDto,
 } from './dto/schedules-response.dto';
+import type { SeminarDetailResponseDto } from './dto/seminar-detail-response.dto';
 import type {
   Attendance,
   AttendancePhase,
@@ -17,11 +18,15 @@ import type {
   ThisWeekResponseDto,
   ThisWeekSeminar,
 } from './dto/this-week-response.dto';
-import { ActiveGenerationNotFoundException } from './seminar.exception';
+import {
+  ActiveGenerationNotFoundException,
+  SeminarNotFoundException,
+} from './seminar.exception';
 import {
   SeminarRepository,
   type AttendanceCheckpoint,
   type SeminarAttendanceRecord,
+  type SeminarItem,
   type SeminarSchedule,
 } from './seminar.repository';
 
@@ -226,8 +231,63 @@ export class SeminarService {
     };
   }
 
-  // TODO(seminar): 후속 커밋에서 구현
-  async getDetail(seminarId: number) {
-    return { seminarId };
+  async getDetail(seminarId: number): Promise<SeminarDetailResponseDto> {
+    const [schedule, sections, items, checkpoints] = await Promise.all([
+      this.seminarRepository.findScheduleById(seminarId),
+      this.seminarRepository.findSectionsBySchedule(seminarId),
+      this.seminarRepository.findItemsBySchedule(seminarId),
+      this.seminarRepository.findCheckpointsBySchedule(seminarId),
+    ]);
+
+    // 운영 정책상 detail 응답은 startedAt 있는 schedule만 노출
+    if (!schedule || schedule.startedAt === null) {
+      throw new SeminarNotFoundException(seminarId);
+    }
+
+    const itemsBySection = new Map<number, SeminarItem[]>();
+    for (const item of items) {
+      const list = itemsBySection.get(item.seminarSectionId) ?? [];
+      list.push(item);
+      itemsBySection.set(item.seminarSectionId, list);
+    }
+
+    const programSections = sections.map((section) => ({
+      sectionNo: section.sortOrder,
+      title: section.title,
+      startsAt: section.startedAt?.toISOString() ?? null,
+      endsAt: section.endedAt?.toISOString() ?? null,
+      items: (itemsBySection.get(section.id) ?? []).map((item) => ({
+        order: item.sortOrder,
+        title: item.title,
+        description: item.description,
+        startsAt: item.startedAt?.toISOString() ?? null,
+      })),
+    }));
+
+    const now = new Date();
+    const attendanceAvailable = checkpoints.some(
+      (cp) => cp.openedAt <= now && now <= cp.closedAt,
+    );
+
+    return {
+      seminarId: schedule.id,
+      title: schedule.title,
+      date: format(
+        toZonedTime(schedule.startedAt, DEFAULT_TIMEZONE),
+        'yyyy-MM-dd',
+      ),
+      startsAt: schedule.startedAt.toISOString(),
+      endsAt: schedule.endedAt?.toISOString() ?? null,
+      location: {
+        name: schedule.venueName,
+        address: schedule.venueAddress,
+        latitude: schedule.venueLat ? parseFloat(schedule.venueLat) : null,
+        longitude: schedule.venueLng ? parseFloat(schedule.venueLng) : null,
+        mapImageUrl: null,
+      },
+      notice: schedule.notice,
+      programSections,
+      attendanceAvailable,
+    };
   }
 }


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> close #44

## 📝 작업 내용

- `GET /seminars/weekly`: 이번 주 단일 세미나 + D-day + viewer 출석 현황
  - `attendance`: phase(BEFORE/IN_PROGRESS/COMPLETED) + viewerName + records
- `GET /seminars/:seminarId`: 세미나 상세 + 타임테이블 + 출석 가능 여부
- 인증 미통합이라 `STUB_VIEWER_ID = 1` 하드코딩 (TODO)

## ✅ 테스트 / 검증 내용

- lint / build / typecheck 통과
- 단위 테스트 21개 통과 (getSchedules 5 + getThisWeek 5 + phase 경계 5 + getDetail 6)
- 로컬 `db:migrate` + `db:seed` 후 `curl /seminars/weekly`, `curl /seminars/:id` 정상 응답
